### PR TITLE
Turn off library evolution because we distribute it as Swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,17 +19,11 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "StreamCore",
-            swiftSettings: [
-                .unsafeFlags(["-enable-library-evolution"])
-            ]
+            name: "StreamCore"
         ),
         .target(
             name: "StreamCoreUI",
-            dependencies: ["StreamCore"],
-            swiftSettings: [
-                .unsafeFlags(["-enable-library-evolution"])
-            ]
+            dependencies: ["StreamCore"]
         ),
         .testTarget(
             name: "StreamCoreTests",

--- a/StreamCore.xcodeproj/project.pbxproj
+++ b/StreamCore.xcodeproj/project.pbxproj
@@ -411,7 +411,6 @@
 		8415DA0F2E462E9F00FEE25F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -445,7 +444,6 @@
 		8415DA102E462E9F00FEE25F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -514,7 +512,6 @@
 		845495322DBA3A1400211413 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -548,7 +545,6 @@
 		845495332DBA3A1400211413 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1154/feeds-library-evolution-warning

### 🎯 Goal

Library evolution is not needed since we do not need binary compatibility

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
