### PR TITLE
Fix WebSocket client concurrency issues

### DIFF
--- a/Tests/StreamCoreTests/Mocks/WebSocketPingController_Mock.swift
+++ b/Tests/StreamCoreTests/Mocks/WebSocketPingController_Mock.swift
@@ -7,11 +7,11 @@ import Foundation
 import XCTest
 
 final class WebSocketPingController_Mock: WebSocketPingController, @unchecked Sendable {
-    var connectionStateDidChange_connectionStates: [WebSocketConnectionState] = []
-    var pongReceivedCount = 0
+    @Atomic var connectionStateDidChange_connectionStates: [WebSocketConnectionState] = []
+    @Atomic var pongReceivedCount = 0
 
     override func connectionStateDidChange(_ connectionState: WebSocketConnectionState) {
-        connectionStateDidChange_connectionStates.append(connectionState)
+        _connectionStateDidChange_connectionStates.mutate { $0.append(connectionState) }
         super.connectionStateDidChange(connectionState)
     }
 

--- a/Tests/StreamCoreTests/WebSockets/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Tests/StreamCoreTests/WebSockets/WebSocketClient/WebSocketClient_Tests.swift
@@ -351,6 +351,15 @@ final class WebSocketClient_Tests: XCTestCase, @unchecked Sendable {
         // Assert completion called
         wait(for: [expectation], timeout: defaultTimeout)
     }
+    
+    func test_recreatingEngineConcurrently() {
+        DispatchQueue.concurrentPerform(iterations: 10000, execute: { _ in
+            guard let url = URL(string: "ws:///\(String.unique)") else { return }
+            self.webSocketClient.connectRequest = URLRequest(url: url)
+            self.webSocketClient.initialize()
+            self.webSocketClient.connect()
+        })
+    }
 }
 
 private final class HealthCheckEvent: @unchecked Sendable, Event, Codable, Hashable {


### PR DESCRIPTION
### 🔗 Issue Links

Fixes: [IOS-1280](https://linear.app/stream/issue/IOS-1280)

### 🎯 Goal

Fix `WebSocketClient` concurrency issues

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
