### PR TITLE
Fix crash when capturing engine in the DispatchQueue closure

### DIFF
--- a/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
+++ b/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
@@ -51,8 +51,13 @@ public class WebSocketClient: @unchecked Sendable {
     private let eventDecoder: AnyEventDecoder
 
     /// The web socket engine used to make the actual WS connection
-    public private(set) var engine: WebSocketEngine?
+    public private(set) var engine: WebSocketEngine? {
+        get { _engine.value }
+        set { _engine.value = newValue }
+    }
 
+    private let _engine = AllocatedUnfairLock<WebSocketEngine?>(nil)
+    
     /// The queue on which web socket engine methods are called
     private let engineQueue: DispatchQueue = .init(label: "io.getstream.core.web_socket_engine_queue", qos: .userInitiated)
 
@@ -128,9 +133,7 @@ public class WebSocketClient: @unchecked Sendable {
         }
 
         guard let connectRequest else { return }
-        engineQueue.sync {
-            engine = createEngineIfNeeded(for: connectRequest)
-        }
+        engine = createEngineIfNeeded(for: connectRequest)
 
         connectionState = .connecting
 


### PR DESCRIPTION
### 🔗 Issue Links

Fixes: [IOS-1336](https://linear.app/stream/issue/IOS-1336/streamcore-test-recreatingengineconcurrently-can-crash)

### 🎯 Goal

Rare crash with capturing engine in the async call

### 📝 Summary

### 🛠 Implementation

When running the `test_recreatingEngineConcurrently` on repeat then it crashed after some time saying that capturing engine was the issue. Which is true, because `self.engine` was not properly guarded. I ran the test on repeat again and works perfectly now.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
