### PR TITLE
Make OpenAPI supporting models Sendable

### DIFF
--- a/Sources/StreamCore/OpenAPI/HTTP/Request.swift
+++ b/Sources/StreamCore/OpenAPI/HTTP/Request.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public enum HTTPMethod: String {
+public enum HTTPMethod: String, Sendable {
     case get = "GET"
     case post = "POST"
     case put = "PUT"
@@ -24,7 +24,7 @@ public enum HTTPMethod: String {
     }
 }
 
-public struct Request {
+public struct Request: Sendable {
     public var url: URL
     public var method: HTTPMethod
     public var body: Data?
@@ -65,4 +65,4 @@ public protocol DefaultAPIClientMiddleware: Sendable {
     ) async throws -> (Data, URLResponse)
 }
 
-public struct EmptyResponse: Codable {}
+public struct EmptyResponse: Codable, Sendable {}

--- a/Sources/StreamCore/OpenAPI/Utils/Models.swift
+++ b/Sources/StreamCore/OpenAPI/Utils/Models.swift
@@ -38,6 +38,8 @@ public enum NullEncodable<Wrapped: Hashable>: Hashable {
     case encodeValue(Wrapped)
 }
 
+extension NullEncodable: Sendable where Wrapped: Sendable {}
+
 extension NullEncodable: Codable where Wrapped: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1620](https://linear.app/stream/issue/IOS-1620)

### 🎯 Goal

Add `Sendable` to models used by OpenAPI

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

While working on OpenAPI generation I found that `EmptyResponse` in the StreamChat is duplicated. StreamCore version is lacking Sendable support. Therefore, this PR adds it + includes some additional models. 

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
