### PR TITLE
Fix reconnection data race leaving WebSocket stuck at .disconnecting

### DIFF
--- a/Sources/StreamCore/WebSocket/Client/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamCore/WebSocket/Client/ConnectionRecoveryHandler.swift
@@ -195,41 +195,11 @@ extension DefaultConnectionRecoveryHandler {
 // MARK: - Disconnection
 
 private extension DefaultConnectionRecoveryHandler {
-    /// Asks the web socket client to disconnect when the system decides we should drop the connection
-    /// (app went to background, internet became unavailable, background task expired, etc.).
-    ///
-    /// The work is dispatched onto `WebSocketClient.engineQueue` to serialize the check-and-act
-    /// (`canBeDisconnected` read + `webSocketClient.disconnect(...)` call) against the engine's
-    /// own state mutations. All `WebSocketEngineDelegate` callbacks — `webSocketDidConnect`,
-    /// `webSocketDidReceiveMessage`, `webSocketDidDisconnect` — run on `engineQueue` and mutate
-    /// `WebSocketClient.connectionState`. By piggy-backing on the same serial queue, our decision
-    /// cannot interleave with theirs.
-    ///
-    /// Bug this prevents: this method is called from multiple queues (main thread for app lifecycle
-    /// events, `io.getstream.internet-monitor` for reachability changes). Previously the flow was:
-    ///
-    ///   1. `canBeDisconnected` reads `connectionState == .connected` on the internet-monitor queue → returns `true`.
-    ///   2. Meanwhile on `engineQueue`, `webSocketDidDisconnect` fires (Wi-Fi just dropped) and sets state to
-    ///      `.disconnected(.serverInitiated)`.
-    ///   3. The internet-monitor queue resumes and unconditionally calls `disconnect(source: .systemInitiated)`,
-    ///      which writes `.disconnecting(.systemInitiated)`, overwriting the legitimate `.disconnected`.
-    ///   4. The engine has already closed the socket, so no further `webSocketDidDisconnect` fires to
-    ///      transition `.disconnecting → .disconnected`. State stays stuck at `.disconnecting`.
-    ///   5. When Wi-Fi returns, `WebSocketAutomaticReconnectionPolicy` rejects reconnection because
-    ///      `isAutomaticReconnectionEnabled` only matches `.disconnected`. The client never recovers.
-    ///
-    /// With this dispatch, the two writers are serialized on the same queue:
-    ///
-    /// - If the engine's `webSocketDidDisconnect` runs **before** this block, we read `.disconnected`,
-    ///   `canBeDisconnected` returns `false`, no `disconnect()` call is made.
-    /// - If this block runs **before** the engine callback, we transition to `.disconnecting` and the
-    ///   queued engine callback then matches the `.disconnecting` case in `WebSocketClient.webSocketDidDisconnect`
-    ///   and transitions to `.disconnected(source: source)`, unblocking reconnection.
-    ///
-    /// Either ordering ends at `.disconnected` — no stuck `.disconnecting` state.
-    ///
-    /// `[weak self]` is used because the handler is owned by the chat/video client and may outlive
-    /// any individual dispatch; we don't want to extend its lifetime past `stop()` / `deinit`.
+    /// Dispatches onto `WebSocketClient.engineQueue` so the `canBeDisconnected` check and the
+    /// `disconnect(...)` call are serialized against `WebSocketEngineDelegate` callbacks, which
+    /// mutate `connectionState` on the same queue. Without this, a concurrent `webSocketDidDisconnect`
+    /// can land `.disconnected` and then be overwritten by `.disconnecting`, leaving the client stuck
+    /// and blocking automatic reconnection.
     func disconnectIfNeeded() {
         webSocketClient.engineQueue.async { [weak self] in
             guard let self else { return }
@@ -260,28 +230,9 @@ private extension DefaultConnectionRecoveryHandler {
 // MARK: - Reconnection
 
 private extension DefaultConnectionRecoveryHandler {
-    /// Asks the web socket client to reconnect when conditions allow it (app returned to foreground,
-    /// internet became available, reconnection timer fired).
-    ///
-    /// Like `disconnectIfNeeded`, the work is dispatched onto `WebSocketClient.engineQueue` to
-    /// serialize against the engine's own state mutations. `WebSocketClient.connect()` reads
-    /// `connectionState` (to early-return when already `.connecting` / `.authenticating` / `.connected`)
-    /// and writes `.connecting`. If that check-and-write raced with the engine's delegate callbacks
-    /// on `engineQueue`, we could end up with the same kind of stale-state overwrite seen in the
-    /// disconnect path (e.g. engine sets `.authenticating` after we've read `.connecting`, then we
-    /// overwrite back to `.connecting`).
-    ///
-    /// Dispatching here also guarantees that `canReconnectAutomatically` — which reads
-    /// `webSocketClient.connectionState` through the reconnection policies — sees the same state
-    /// the engine sees when this block runs, with no possibility of a delegate callback mutating
-    /// state between our read and the `connect()` call.
-    ///
-    /// Entry points (all hop onto `engineQueue` here):
-    /// - `appDidBecomeActive` (main thread)
-    /// - `internetConnectionAvailabilityDidChange` with `isAvailable == true` (`io.getstream.internet-monitor` queue)
-    /// - `scheduleReconnectionTimer` fire (main thread)
-    ///
-    /// `[weak self]` for the same reason as in `disconnectIfNeeded`.
+    /// Mirrors `disconnectIfNeeded`: the check (`canReconnectAutomatically`) and the act
+    /// (`webSocketClient.connect()`) are dispatched onto `engineQueue` so they cannot race with
+    /// the engine's own state mutations.
     func reconnectIfNeeded() {
         webSocketClient.engineQueue.async { [weak self] in
             guard let self else { return }

--- a/Sources/StreamCore/WebSocket/Client/ConnectionRecoveryHandler.swift
+++ b/Sources/StreamCore/WebSocket/Client/ConnectionRecoveryHandler.swift
@@ -195,11 +195,49 @@ extension DefaultConnectionRecoveryHandler {
 // MARK: - Disconnection
 
 private extension DefaultConnectionRecoveryHandler {
+    /// Asks the web socket client to disconnect when the system decides we should drop the connection
+    /// (app went to background, internet became unavailable, background task expired, etc.).
+    ///
+    /// The work is dispatched onto `WebSocketClient.engineQueue` to serialize the check-and-act
+    /// (`canBeDisconnected` read + `webSocketClient.disconnect(...)` call) against the engine's
+    /// own state mutations. All `WebSocketEngineDelegate` callbacks — `webSocketDidConnect`,
+    /// `webSocketDidReceiveMessage`, `webSocketDidDisconnect` — run on `engineQueue` and mutate
+    /// `WebSocketClient.connectionState`. By piggy-backing on the same serial queue, our decision
+    /// cannot interleave with theirs.
+    ///
+    /// Bug this prevents: this method is called from multiple queues (main thread for app lifecycle
+    /// events, `io.getstream.internet-monitor` for reachability changes). Previously the flow was:
+    ///
+    ///   1. `canBeDisconnected` reads `connectionState == .connected` on the internet-monitor queue → returns `true`.
+    ///   2. Meanwhile on `engineQueue`, `webSocketDidDisconnect` fires (Wi-Fi just dropped) and sets state to
+    ///      `.disconnected(.serverInitiated)`.
+    ///   3. The internet-monitor queue resumes and unconditionally calls `disconnect(source: .systemInitiated)`,
+    ///      which writes `.disconnecting(.systemInitiated)`, overwriting the legitimate `.disconnected`.
+    ///   4. The engine has already closed the socket, so no further `webSocketDidDisconnect` fires to
+    ///      transition `.disconnecting → .disconnected`. State stays stuck at `.disconnecting`.
+    ///   5. When Wi-Fi returns, `WebSocketAutomaticReconnectionPolicy` rejects reconnection because
+    ///      `isAutomaticReconnectionEnabled` only matches `.disconnected`. The client never recovers.
+    ///
+    /// With this dispatch, the two writers are serialized on the same queue:
+    ///
+    /// - If the engine's `webSocketDidDisconnect` runs **before** this block, we read `.disconnected`,
+    ///   `canBeDisconnected` returns `false`, no `disconnect()` call is made.
+    /// - If this block runs **before** the engine callback, we transition to `.disconnecting` and the
+    ///   queued engine callback then matches the `.disconnecting` case in `WebSocketClient.webSocketDidDisconnect`
+    ///   and transitions to `.disconnected(source: source)`, unblocking reconnection.
+    ///
+    /// Either ordering ends at `.disconnected` — no stuck `.disconnecting` state.
+    ///
+    /// `[weak self]` is used because the handler is owned by the chat/video client and may outlive
+    /// any individual dispatch; we don't want to extend its lifetime past `stop()` / `deinit`.
     func disconnectIfNeeded() {
-        guard canBeDisconnected else { return }
-        
-        webSocketClient.disconnect(source: .systemInitiated) {
-            log.debug("Did disconnect automatically", subsystems: .webSocket)
+        webSocketClient.engineQueue.async { [weak self] in
+            guard let self else { return }
+            guard self.canBeDisconnected else { return }
+            log.debug("\(self.webSocketClient.connectionState)", subsystems: .webSocket)
+            self.webSocketClient.disconnect(source: .systemInitiated) {
+                log.debug("Did disconnect automatically", subsystems: .webSocket)
+            }
         }
     }
     
@@ -207,7 +245,7 @@ private extension DefaultConnectionRecoveryHandler {
         let state = webSocketClient.connectionState
         
         switch state {
-        case .connecting, .authenticating, .connected, .disconnecting:
+        case .connecting, .authenticating, .connected:
             log.debug("Will disconnect automatically from \(state) state", subsystems: .webSocket)
             
             return true
@@ -222,10 +260,34 @@ private extension DefaultConnectionRecoveryHandler {
 // MARK: - Reconnection
 
 private extension DefaultConnectionRecoveryHandler {
+    /// Asks the web socket client to reconnect when conditions allow it (app returned to foreground,
+    /// internet became available, reconnection timer fired).
+    ///
+    /// Like `disconnectIfNeeded`, the work is dispatched onto `WebSocketClient.engineQueue` to
+    /// serialize against the engine's own state mutations. `WebSocketClient.connect()` reads
+    /// `connectionState` (to early-return when already `.connecting` / `.authenticating` / `.connected`)
+    /// and writes `.connecting`. If that check-and-write raced with the engine's delegate callbacks
+    /// on `engineQueue`, we could end up with the same kind of stale-state overwrite seen in the
+    /// disconnect path (e.g. engine sets `.authenticating` after we've read `.connecting`, then we
+    /// overwrite back to `.connecting`).
+    ///
+    /// Dispatching here also guarantees that `canReconnectAutomatically` — which reads
+    /// `webSocketClient.connectionState` through the reconnection policies — sees the same state
+    /// the engine sees when this block runs, with no possibility of a delegate callback mutating
+    /// state between our read and the `connect()` call.
+    ///
+    /// Entry points (all hop onto `engineQueue` here):
+    /// - `appDidBecomeActive` (main thread)
+    /// - `internetConnectionAvailabilityDidChange` with `isAvailable == true` (`io.getstream.internet-monitor` queue)
+    /// - `scheduleReconnectionTimer` fire (main thread)
+    ///
+    /// `[weak self]` for the same reason as in `disconnectIfNeeded`.
     func reconnectIfNeeded() {
-        guard canReconnectAutomatically else { return }
-                
-        webSocketClient.connect()
+        webSocketClient.engineQueue.async { [weak self] in
+            guard let self else { return }
+            guard self.canReconnectAutomatically else { return }
+            self.webSocketClient.connect()
+        }
     }
     
     var canReconnectAutomatically: Bool {

--- a/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
+++ b/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
@@ -58,8 +58,9 @@ public class WebSocketClient: @unchecked Sendable {
 
     private let _engine = AllocatedUnfairLock<WebSocketEngine?>(nil)
     
-    /// The queue on which web socket engine methods are called
-    private let engineQueue: DispatchQueue = .init(label: "io.getstream.core.web_socket_engine_queue", qos: .userInitiated)
+    /// The queue on which web socket engine methods are called.
+    /// Also used by the connection recovery handler to serialize check-and-act sequences against engine state mutations.
+    let engineQueue: DispatchQueue = .init(label: "io.getstream.core.web_socket_engine_queue", qos: .userInitiated)
 
     /// The session config used for the web socket engine
     private let sessionConfiguration: URLSessionConfiguration

--- a/Tests/StreamCoreTests/WebSockets/WebSocketClient/ConnectionRecoveryHandler_Tests.swift
+++ b/Tests/StreamCoreTests/WebSockets/WebSocketClient/ConnectionRecoveryHandler_Tests.swift
@@ -92,7 +92,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase, @unchecked Sendable {
             )
             posted.fulfill()
         }
-        wait(for: [posted], timeout: 1)
+        wait(for: [posted], timeout: defaultTimeout)
     }
 
     /// Enqueues a no-op block on `engineQueue` and waits for it to run, ensuring all previously
@@ -100,7 +100,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase, @unchecked Sendable {
     private func drainEngineQueue() {
         let drained = expectation(description: "engineQueue drained")
         webSocketClient.engineQueue.async { drained.fulfill() }
-        wait(for: [drained], timeout: 2)
+        wait(for: [drained], timeout: defaultTimeout)
     }
 
     // MARK: - Test 1: disconnectIfNeeded must dispatch onto engineQueue
@@ -177,7 +177,7 @@ final class ConnectionRecoveryHandler_Tests: XCTestCase, @unchecked Sendable {
 
             let bothDone = expectation(description: "both threads done iter \(iteration)")
             group.notify(queue: .global()) { bothDone.fulfill() }
-            wait(for: [bothDone], timeout: 2)
+            wait(for: [bothDone], timeout: defaultTimeout)
 
             drainEngineQueue()
 

--- a/Tests/StreamCoreTests/WebSockets/WebSocketClient/ConnectionRecoveryHandler_Tests.swift
+++ b/Tests/StreamCoreTests/WebSockets/WebSocketClient/ConnectionRecoveryHandler_Tests.swift
@@ -1,0 +1,217 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+@testable import StreamCore
+import XCTest
+
+/// Regression tests for the data race between `DefaultConnectionRecoveryHandler` and the WebSocket
+/// engine queue. See plan file `quizzical-jumping-bunny.md` for the full bug analysis.
+///
+/// The bug: `disconnectIfNeeded()` performs a check-then-act on `webSocketClient.connectionState`.
+/// Without the fix, the check runs on the caller's queue (typically `io.getstream.internet-monitor`)
+/// and `disconnect(...)` writes `.disconnecting` from that same queue. The engine queue can
+/// independently write `.disconnected` between the check and the write, after which the handler's
+/// stale write overwrites the legitimate `.disconnected`. The engine then never re-fires
+/// `webSocketDidDisconnect`, so state stays stuck at `.disconnecting`.
+///
+/// The fix wraps `disconnectIfNeeded` and `reconnectIfNeeded` in `webSocketClient.engineQueue.async`,
+/// serializing the handler's check-and-act with the engine's own state writes.
+final class ConnectionRecoveryHandler_Tests: XCTestCase, @unchecked Sendable {
+    private var webSocketClient: WebSocketClient!
+    private var eventNotificationCenter: EventNotificationCenter_Mock!
+    private var internetMonitor: InternetConnectionMonitor_Mock!
+    private var internetConnection: InternetConnection!
+    private var handler: DefaultConnectionRecoveryHandler!
+    private var time: VirtualTime!
+
+    private let healthCheckInfo = HealthCheckInfo(connectionId: "test-connection-id")
+
+    override func setUp() {
+        super.setUp()
+
+        time = VirtualTime()
+        VirtualTimeTimer.time = time
+
+        eventNotificationCenter = EventNotificationCenter_Mock()
+
+        var environment = WebSocketClient.Environment.mock
+        environment.timerType = VirtualTimeTimer.self
+
+        webSocketClient = WebSocketClient(
+            sessionConfiguration: .ephemeral,
+            eventDecoder: EventDecoder_Mock(),
+            eventNotificationCenter: eventNotificationCenter,
+            webSocketClientType: .coordinator,
+            environment: environment,
+            connectRequest: URLRequest(url: URL(string: "http://example.com/ws")!)
+        )
+
+        // Use an isolated NotificationCenter so tests don't observe each other.
+        internetMonitor = InternetConnectionMonitor_Mock()
+        internetConnection = InternetConnection(
+            notificationCenter: NotificationCenter(),
+            monitor: internetMonitor
+        )
+
+        handler = DefaultConnectionRecoveryHandler(
+            webSocketClient: webSocketClient,
+            eventNotificationCenter: eventNotificationCenter,
+            backgroundTaskScheduler: nil,
+            internetConnection: internetConnection,
+            reconnectionStrategy: DefaultRetryStrategy(),
+            reconnectionTimerType: VirtualTimeTimer.self,
+            keepConnectionAliveInBackground: false
+        )
+    }
+
+    override func tearDown() {
+        handler?.stop()
+        handler = nil
+        internetConnection = nil
+        internetMonitor = nil
+        webSocketClient = nil
+        eventNotificationCenter = nil
+        VirtualTimeTimer.invalidate()
+        time = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Posts `.internetConnectionAvailabilityDidChange` synchronously from `queue` and waits for the
+    /// observer chain to drain. The handler's `@objc` selector runs on `queue` because the observer
+    /// was registered without an explicit `OperationQueue`.
+    private func postInternetAvailability(_ status: InternetConnectionStatus, from queue: DispatchQueue) {
+        let posted = expectation(description: "notification posted on \(queue.label)")
+        queue.async { [internetConnection] in
+            internetConnection!.notificationCenter.post(
+                name: .internetConnectionAvailabilityDidChange,
+                object: internetConnection,
+                userInfo: [Notification.internetConnectionStatusUserInfoKey: status]
+            )
+            posted.fulfill()
+        }
+        wait(for: [posted], timeout: 1)
+    }
+
+    /// Enqueues a no-op block on `engineQueue` and waits for it to run, ensuring all previously
+    /// queued work has completed.
+    private func drainEngineQueue() {
+        let drained = expectation(description: "engineQueue drained")
+        webSocketClient.engineQueue.async { drained.fulfill() }
+        wait(for: [drained], timeout: 2)
+    }
+
+    // MARK: - Test 1: disconnectIfNeeded must dispatch onto engineQueue
+
+    /// Verifies the fix's mechanism. When the internet-down notification arrives on a non-engine
+    /// queue, the handler must NOT write to `connectionState` synchronously from that queue.
+    ///
+    /// Without the fix this assertion fails: the handler runs `canBeDisconnected` synchronously,
+    /// then calls `webSocketClient.disconnect(source: .systemInitiated)`, which writes
+    /// `.disconnecting` on the internet-monitor queue immediately. We observe that write as soon
+    /// as `post()` returns. With the fix, the handler's block is queued onto the suspended
+    /// `engineQueue`, so state is still `.connected` at the moment of assertion.
+    func test_disconnectIfNeeded_dispatchesOntoEngineQueue() {
+        webSocketClient.connectionState = .connected(healthCheckInfo: healthCheckInfo)
+
+        webSocketClient.engineQueue.suspend()
+        defer { webSocketClient.engineQueue.resume() }
+
+        let internetMonitorQueue = DispatchQueue(label: "test.internet-monitor")
+        postInternetAvailability(.unavailable, from: internetMonitorQueue)
+
+        XCTAssertEqual(
+            webSocketClient.connectionState,
+            .connected(healthCheckInfo: healthCheckInfo),
+            "Handler must not mutate connectionState on the caller's queue; it must dispatch onto engineQueue."
+        )
+    }
+
+    // MARK: - Test 2: real race — concurrent engine fire + internet-down never sticks at .disconnecting
+
+    /// Real-world race shape. Runs many iterations of: `webSocketDidDisconnect` on `engineQueue`
+    /// concurrent with the internet-down notification on a separate queue. With the fix, state
+    /// always ends at `.disconnected`. Without the fix, some iterations may end at `.disconnecting`
+    /// when the threads interleave as:
+    ///
+    ///   1. handler's `canBeDisconnected` reads `.connected`
+    ///   2. engine's `webSocketDidDisconnect` writes `.disconnected`
+    ///   3. handler's `disconnect()` writes `.disconnecting`
+    ///
+    /// — and no further engine callback fires to recover.
+    ///
+    /// Note: this is a best-effort stress test. The race window between handler's check and act
+    /// is narrow (a few CPU instructions plus a log statement), so the bug may not reproduce
+    /// reliably on every machine. Tests 1 and 3 are the authoritative regression checks; this
+    /// test gives additional confidence under load.
+    func test_concurrentEngineDisconnectAndInternetDown_neverStucksAtDisconnecting() {
+        let iterations = 2000
+
+        for iteration in 0..<iterations {
+            webSocketClient.connectionState = .connected(healthCheckInfo: healthCheckInfo)
+
+            let internetMonitorQueue = DispatchQueue(label: "test.internet-monitor.\(iteration)")
+            let group = DispatchGroup()
+
+            // Pre-queue the engine's webSocketDidDisconnect onto engineQueue (without barrier) so
+            // it starts as soon as possible. Then post the notification on a separate queue.
+            // Letting both run without a barrier increases the chance their orderings interleave
+            // through all three race positions across iterations.
+            group.enter()
+            webSocketClient.engineQueue.async { [webSocketClient] in
+                webSocketClient!.webSocketDidDisconnect(error: nil)
+                group.leave()
+            }
+
+            group.enter()
+            internetMonitorQueue.async { [internetConnection] in
+                internetConnection!.notificationCenter.post(
+                    name: .internetConnectionAvailabilityDidChange,
+                    object: internetConnection,
+                    userInfo: [Notification.internetConnectionStatusUserInfoKey: InternetConnectionStatus.unavailable]
+                )
+                group.leave()
+            }
+
+            let bothDone = expectation(description: "both threads done iter \(iteration)")
+            group.notify(queue: .global()) { bothDone.fulfill() }
+            wait(for: [bothDone], timeout: 2)
+
+            drainEngineQueue()
+
+            if case .disconnecting = webSocketClient.connectionState {
+                XCTFail(
+                    "Iteration \(iteration): connectionState stuck at \(webSocketClient.connectionState). " +
+                        "The handler's call to disconnect() overwrote the engine's .disconnected write."
+                )
+                return
+            }
+        }
+    }
+
+    // MARK: - Test 3: reconnectIfNeeded must dispatch onto engineQueue (symmetric)
+
+    /// Symmetric to Test 1 but for the reconnect path. When state is `.disconnected` and the
+    /// internet returns, the handler must NOT write `.connecting` synchronously from the
+    /// internet-monitor queue. It must dispatch onto `engineQueue`.
+    func test_reconnectIfNeeded_dispatchesOntoEngineQueue() {
+        webSocketClient.connectionState = .disconnected(source: .serverInitiated(error: nil))
+
+        // Make the internet availability policy return true.
+        internetMonitor.status = .available(.great)
+
+        webSocketClient.engineQueue.suspend()
+        defer { webSocketClient.engineQueue.resume() }
+
+        let internetMonitorQueue = DispatchQueue(label: "test.internet-monitor")
+        postInternetAvailability(.available(.great), from: internetMonitorQueue)
+
+        XCTAssertEqual(
+            webSocketClient.connectionState,
+            .disconnected(source: .serverInitiated(error: nil)),
+            "Handler must not mutate connectionState on the caller's queue for reconnect; it must dispatch onto engineQueue."
+        )
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1715](https://linear.app/stream/issue/IOS-1715)

### 🎯 Goal

When the device loses and regains Wi-Fi, the WebSocket would sometimes stay stuck in `.disconnecting` and never reconnect. The root cause is a data race between `DefaultConnectionRecoveryHandler.disconnectIfNeeded()` (which runs on `io.getstream.internet-monitor`) and `WebSocketClient`'s engine-driven state writes (on `engineQueue`). The handler performs a check-then-act on `connectionState`: it reads `.connected`, the engine queue independently writes `.disconnected(.serverInitiated)`, then the handler unconditionally writes `.disconnecting(.systemInitiated)` — overwriting the legitimate `.disconnected`. The engine has already closed the socket and never re-fires `webSocketDidDisconnect`, so the state stays stuck. `WebSocketAutomaticReconnectionPolicy` then refuses to reconnect because `isAutomaticReconnectionEnabled` only matches `.disconnected`.

### 📝 Summary

- Wrap the bodies of `disconnectIfNeeded()` and `reconnectIfNeeded()` in `webSocketClient.engineQueue.async { ... }` so the handler's check-and-act runs on the same serial queue that owns the engine's state mutations.
- Widen `WebSocketClient.engineQueue` from `private` to internal access so the handler in the same module can dispatch onto it.
- Add `ConnectionRecoveryHandler_Tests` with three regression tests: two deterministic (the handler must not mutate `connectionState` from the caller's queue) and one stress test (2000 concurrent engine-disconnect / internet-down iterations).

### 🛠 Implementation

Both writers (the handler and the engine's `WebSocketEngineDelegate` callbacks) now run on `WebSocketClient.engineQueue` — a serial dispatch queue. That serialises the previously racing accesses without introducing new locks or actor boundaries. Two possible orderings remain, and both end correctly at `.disconnected`:

- Engine's `webSocketDidDisconnect` runs first → handler block runs second, sees `.disconnected`, `canBeDisconnected` returns `false`, no `disconnect()` call.
- Handler block runs first → transitions to `.disconnecting`, queued engine callback then matches the `.disconnecting` case in `WebSocketClient.webSocketDidDisconnect` and transitions to `.disconnected(source: source)`.

Deadlock-safety was audited: every `engineQueue` usage in the codebase is `.async` (no `.sync`); `@Atomic`'s lock and `AllocatedUnfairLock` for `_engine`/`_connectRequest` are never nested; the `connectionState` `didSet` (and therefore the delegate notification) fires outside the `@Atomic` setter's lock; the ping-controller call chain (`disconnectOnNoPongReceived` → `disconnect`) was traced through — no synchronous re-entry hazards.

The earlier `@Atomic` + `didSet` issue (observers within a single `didSet` reading inconsistent values) is intentionally out of scope here.

### 🧪 Manual Testing Notes

Reproduce the original bug scenario on a physical iPhone:

1. Launch the app, sign in, confirm `Web socket connection state changed: connected(...)` in logs.
2. Turn Wi-Fi **off**. State should reach `.disconnected(.serverInitiated)`. It should not flip to `.disconnecting(.systemInitiated)`; if it does, it must immediately return to `.disconnected` (the engine's recovery path through the `.disconnecting` case).
3. Wait ~10 seconds.
4. Turn Wi-Fi **on**. Reconnection should fire automatically: `canReconnectAutomatically? true ...` → `webSocketClient.connect happening ...` → `connecting → authenticating → connected(...)`.
5. Sanity check the lifecycle path: foreground → background → foreground while connected. Disconnect on background, reconnect on foreground, no stuck state.

The new unit tests run as part of the `StreamCoreTests` target.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo