### PR TITLE
Fix Sendable errors in Sort when building with Xcode 27

### DIFF
--- a/Sources/StreamCore/OpenAPI/Query/Sort.swift
+++ b/Sources/StreamCore/OpenAPI/Query/Sort.swift
@@ -26,7 +26,7 @@ public protocol SortField: Sendable {
     /// - Parameters:
     ///   - rawValue: The string identifier used for remote API requests
     ///   - localValue: A closure that extracts the comparable value from a model instance
-    init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable
+    init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable
 }
 
 /// A sort configuration that combines a sort field with a direction.
@@ -142,8 +142,11 @@ public struct AnySortComparator<Model>: Sendable where Model: Sendable {
     /// Creates a type-erased comparator from a specific comparator instance.
     ///
     /// - Parameter sort: The specific comparator to wrap
-    public init<Value: Comparable>(localValue: @escaping @Sendable (Model) -> Value) {
-        compare = SortComparator(localValue: localValue).compare
+    public init<Value: Comparable & Sendable>(localValue: @escaping @Sendable (Model) -> Value) {
+        let comparator = SortComparator(localValue: localValue)
+        compare = { @Sendable lhs, rhs, direction in
+            comparator.compare(lhs, rhs, direction: direction)
+        }
     }
     
     /// Compares two model instances using the wrapped comparator.


### PR DESCRIPTION
### 🔗 Issue Links

[IOS-1751](https://linear.app/stream/issue/IOS-1751/xcode-27-compatibility-for-chat)

### 🎯 Goal

Fix strict-concurrency compile errors in `Sort.swift` when building with Xcode 27.

### 📝 Summary

- Added `Sendable` to the `Value` generic constraint in the `SortField` initializer requirement and in `AnySortComparator.init`.
- `AnySortComparator.init` now wraps the comparator in an explicit `@Sendable` closure instead of storing the unapplied `SortComparator.compare` method reference.

### 🛠 Implementation

`AnySortComparator` stores its comparison as a `@Sendable` closure, so everything that closure captures must be `Sendable`. The captured `SortComparator` is only `Sendable` when the extracted `Value` is, which the Xcode 27 compiler now enforces — hence the added `Value: Comparable & Sendable` constraints on `AnySortComparator.init` and on the `SortField` initializer requirement that feeds it. The unapplied `compare` method reference is also no longer accepted where a `@Sendable` closure is expected, so it is wrapped in an explicit `@Sendable` closure.

### 🧪 Manual Testing Notes

Build the package with Xcode 27 — `Sort.swift` no longer produces Sendable diagnostics.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo