### PR TITLE
Add APIHelper.escapedPathItem path-escaping convenience

### DIFF
--- a/Sources/StreamCore/OpenAPI/Utils/APIHelper.swift
+++ b/Sources/StreamCore/OpenAPI/Utils/APIHelper.swift
@@ -63,6 +63,15 @@ public enum APIHelper {
         return source
     }
 
+    /// Maps a value to a single path component and percent-encodes it for use in a URL path.
+    /// Folds the previous two-step `mapValueToPathItem` + `addingPercentEncoding` into one call
+    /// so generated endpoint paths stay compact. A `nil` value maps to an empty component.
+    public static func escapedPathItem(_ value: Any?) -> String {
+        guard let value else { return "" }
+        let item = "\(mapValueToPathItem(value))"
+        return item.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+    }
+
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs

--- a/Tests/StreamCoreTests/OpenAPI/Utils/APIHelper_Tests.swift
+++ b/Tests/StreamCoreTests/OpenAPI/Utils/APIHelper_Tests.swift
@@ -1,0 +1,57 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Foundation
+@testable import StreamCore
+import Testing
+
+struct APIHelper_Tests {
+    // MARK: - escapedPathItem
+
+    @Test("Plain string with only allowed characters passes through unchanged")
+    func escapedPathItem_plainString() {
+        #expect(APIHelper.escapedPathItem("simple-id_123.~") == "simple-id_123.~")
+    }
+
+    @Test("Characters disallowed in a path are percent-encoded")
+    func escapedPathItem_encodesDisallowedCharacters() {
+        #expect(APIHelper.escapedPathItem("a b") == "a%20b")
+        #expect(APIHelper.escapedPathItem("a#b") == "a%23b")
+        #expect(APIHelper.escapedPathItem("a?b") == "a%3Fb")
+        #expect(APIHelper.escapedPathItem("100%") == "100%25")
+        // ":" is not in .urlPathAllowed, so a channel CID's separator is encoded.
+        #expect(APIHelper.escapedPathItem("messaging:general") == "messaging%3Ageneral")
+    }
+
+    @Test("Characters allowed in a URL path are not encoded")
+    func escapedPathItem_keepsPathAllowedCharacters() {
+        // .urlPathAllowed permits "/", "@", ",", ";", matching the legacy
+        // per-parameter escaping the generated EndpointPath relied on.
+        #expect(APIHelper.escapedPathItem("a/b@c,d;e") == "a/b@c,d;e")
+    }
+
+    @Test("Array value is comma-joined then escaped")
+    func escapedPathItem_arrayValue() {
+        #expect(APIHelper.escapedPathItem(["a", "b c"]) == "a,b%20c")
+    }
+
+    @Test("nil value maps to an empty component")
+    func escapedPathItem_nil() {
+        #expect(APIHelper.escapedPathItem(nil) == "")
+    }
+
+    @Test("Matches the previous two-step mapValueToPathItem + addingPercentEncoding")
+    func escapedPathItem_matchesLegacyTwoStep() {
+        for value in ["foo bar/baz", "100% done", "messaging:general"] as [Any] {
+            let preEscape = "\(APIHelper.mapValueToPathItem(value))"
+            let postEscape = preEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+            #expect(APIHelper.escapedPathItem(value) == postEscape)
+        }
+
+        let array: [String] = ["a", "b c", "d/e"]
+        let preEscape = "\(APIHelper.mapValueToPathItem(array))"
+        let postEscape = preEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
+        #expect(APIHelper.escapedPathItem(array) == postEscape)
+    }
+}


### PR DESCRIPTION
### 🔗 Issue Links

- https://linear.app/stream/issue/IOS-1620/openapi-generation-in-llc

### 🎯 Goal

The OpenAPI Swift generator (in the `chat` repo) emits an `EndpointPath` enum whose
`value` produces, for every path parameter, two boilerplate locals before the
`return`:

```swift
let messageIdPreEscape = "\(APIHelper.mapValueToPathItem(messageId))"
let messageIdPostEscape = messageIdPreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
```

This adds a single helper so the generator can collapse that into one inline call,
keeping the generated paths compact while preserving the exact escaping behavior.

### 📝 Summary

- Add `APIHelper.escapedPathItem(_:)` which folds `mapValueToPathItem` +
  `addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)` into one call.
- Add unit tests for the new helper.

### 🛠 Implementation

`escapedPathItem` reuses the existing `mapValueToPathItem` (so array values are still
comma-joined) and then percent-encodes with `.urlPathAllowed`, identical to the prior
two-step logic. A `nil` value maps to an empty component. A dedicated test asserts
equivalence with the old `"\(mapValueToPathItem(x))".addingPercentEncoding(...)` form
so the refactor on the generator side is provably behavior-preserving.

Note: `.urlPathAllowed` permits `/`, `@`, `,`, `;` but encodes `:` (e.g. a channel CID
`messaging:general` → `messaging%3Ageneral`) and space/`#`/`?`/`%` — matching the
existing behavior.

The matching generator change lives in the `chat` repo and will start emitting
`\(APIHelper.escapedPathItem(...))` in `DefaultEndpoints.swift`.

### 🧪 Manual Testing Notes

`StreamCoreTests/APIHelper_Tests` (6 cases) passes on the iOS simulator:
`xcodebuild test -scheme StreamCore -only-testing:StreamCoreTests/APIHelper_Tests`.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
