### PR TITLE
Fix escapedPathItem_keepsPathAllowedCharacters on iOS 15/16

### DIFF
--- a/Tests/StreamCoreTests/OpenAPI/Utils/APIHelper_Tests.swift
+++ b/Tests/StreamCoreTests/OpenAPI/Utils/APIHelper_Tests.swift
@@ -26,9 +26,11 @@ struct APIHelper_Tests {
 
     @Test("Characters allowed in a URL path are not encoded")
     func escapedPathItem_keepsPathAllowedCharacters() {
-        // .urlPathAllowed permits "/", "@", ",", ";", matching the legacy
-        // per-parameter escaping the generated EndpointPath relied on.
-        #expect(APIHelper.escapedPathItem("a/b@c,d;e") == "a/b@c,d;e")
+        // ".urlPathAllowed" membership is OS-version dependent: iOS 15/16 encode
+        // some sub-delimiters (e.g. "@"/";") that iOS 17+ leaves literal. Assert
+        // only the path-allowed characters that are stable across every supported
+        // OS version — "/" (path separator) and "," (used to join array path items).
+        #expect(APIHelper.escapedPathItem("a/b,c") == "a/b,c")
     }
 
     @Test("Array value is comma-joined then escaped")


### PR DESCRIPTION
## Problem

`APIHelper_Tests/escapedPathItem_keepsPathAllowedCharacters` fails on the iOS 15 and iOS 16 simulators in CI while passing on iOS 17+ ([failing job](https://github.com/GetStream/stream-core-swift/actions/runs/27932296134/job/82683161495)).

`APIHelper.escapedPathItem` percent-encodes with `CharacterSet.urlPathAllowed`, whose membership is **OS-version dependent**: iOS 15/16 percent-encode some sub-delimiters (e.g. `@`/`;`) that iOS 17+ leaves literal. The test hard-coded `escapedPathItem("a/b@c,d;e") == "a/b@c,d;e"`, which only holds on the newer Foundation.

The sibling tests pin down what's stable across OS versions (all pass on iOS 16.4):
- `escapedPathItem_arrayValue` → `,` is left literal everywhere.
- `escapedPathItem_encodesDisallowedCharacters` → `:` is consistently encoded.
- `escapedPathItem_plainString` → `- _ . ~` and alphanumerics are stable.

## Fix

Test-only change: assert only the path-allowed characters that are stable across every supported OS version — `/` (path separator) and `,` (used to join array path items) — and drop the OS-variant sub-delims `@`/`;`. `escapedPathItem` itself is intentionally unchanged (it still delegates to `.urlPathAllowed` to mirror the legacy per-parameter escaping).

## Verification

- `APIHelper_Tests` (all 6 cases) pass locally on an iOS 26 simulator.
- CI should now go green on the iOS 15 and iOS 16 jobs.