### PR TITLE
Add code documentation guidelines for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+Guidance for AI coding agents (Copilot, Cursor, Aider, Claude, etc.) working in this repository. Human readers are welcome, but this file is written for tools.
+
+### Repository purpose
+
+This repo hosts StreamCore, the internal Swift SDK that provides shared low-level infrastructure — WebSocket client, retry/backoff logic, logging and monitoring, dependency injection, attachment uploads, and user models — for Stream's product SDKs (StreamFeeds, StreamChat, StreamVideo). It is not designed for direct customer use and does not follow semantic versioning.
+
+### Development guidelines
+
+Code documentation
+
+- Write doc comments (`///`) only for `public` declarations — types, methods, and properties that are part of the SDK's public API.
+- Do not add doc comments to `internal`, `private`, or test code.
+- Keep doc comments concise: a one-line summary; add parameter/return docs only when they are not obvious from the signature.
+- Do not add inline comments narrating what the code or a change does; comment only non-obvious constraints or reasoning.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### 🔗 Issue Links

None.

### 🎯 Goal

Prevent AI coding agents from generating verbose doc comments by documenting that only public API gets doc comments.

### 📝 Summary

- Added `AGENTS.md` with the repository purpose and a "Code documentation" policy: doc comments (`///`) only for public declarations, kept concise, and no comments narrating changes.
- Added `CLAUDE.md` importing `AGENTS.md`, matching the other Stream Swift repos.

### 🛠 Implementation

Documentation-only change adding agent guidance files; no source code affected.

### 🎨 Showcase

Not applicable — documentation-only change.

### 🧪 Manual Testing Notes

Not applicable — documentation-only change.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
