### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -15,6 +15,9 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Test

--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -6,6 +6,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   merge-release-to-main:
     name: Merge release to main

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,6 +3,9 @@ name: "Publish new release"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Publish new release

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -8,6 +8,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   test-release:
     name: Start new release

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -24,6 +24,11 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
 jobs:
   test_core:
     name: Test Core

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,6 +12,9 @@ concurrency:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     runs-on: macos-15

--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -10,6 +10,9 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
+permissions:
+  contents: read
+
 jobs:
   copyright:
     name: Copyright


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **13** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
