### PR TITLE
Add APIHelper.mapValuesToQueryDictionary query-item helper

### DIFF
--- a/Sources/StreamCore/OpenAPI/Utils/APIHelper.swift
+++ b/Sources/StreamCore/OpenAPI/Utils/APIHelper.swift
@@ -123,9 +123,9 @@ public enum APIHelper {
         return destination
     }
 
-    /// maps all values from source to a query-parameter dictionary
+    /// Maps all values from source to a query-parameter dictionary
     ///
-    /// keys whose value is nil are omitted; collection values are comma-joined
+    /// Keys whose value is nil are omitted; collection values are comma-joined.
     public static func mapValuesToQueryDictionary(_ source: [String: Any?]) -> [String: String]? {
         let destination = source.filter { $0.value != nil }.reduce(into: [String: String]()) { result, item in
             if let collection = item.value as? [Any?] {

--- a/Sources/StreamCore/OpenAPI/Utils/APIHelper.swift
+++ b/Sources/StreamCore/OpenAPI/Utils/APIHelper.swift
@@ -122,4 +122,24 @@ public enum APIHelper {
         }
         return destination
     }
+
+    /// maps all values from source to a query-parameter dictionary
+    ///
+    /// keys whose value is nil are omitted; collection values are comma-joined
+    public static func mapValuesToQueryDictionary(_ source: [String: Any?]) -> [String: String]? {
+        let destination = source.filter { $0.value != nil }.reduce(into: [String: String]()) { result, item in
+            if let collection = item.value as? [Any?] {
+                result[item.key] = collection
+                    .compactMap { value in convertAnyToString(value) }
+                    .joined(separator: ",")
+            } else if let value = item.value {
+                result[item.key] = convertAnyToString(value)
+            }
+        }
+
+        if destination.isEmpty {
+            return nil
+        }
+        return destination
+    }
 }

--- a/Tests/StreamCoreTests/OpenAPI/Utils/APIHelper_Tests.swift
+++ b/Tests/StreamCoreTests/OpenAPI/Utils/APIHelper_Tests.swift
@@ -56,4 +56,53 @@ struct APIHelper_Tests {
         let postEscape = preEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         #expect(APIHelper.escapedPathItem(array) == postEscape)
     }
+
+    // MARK: - mapValuesToQueryDictionary
+
+    @Test("Mirrors a generated endpoint call: nil optionals are dropped, others kept")
+    func mapValuesToQueryDictionary_dropsNilOptionals() {
+        let query = "adm"
+        let limit: Int? = 10
+        let nameGt: String? = nil
+        let roleType: String? = "user"
+        let includeGlobalRoles: Bool? = nil
+
+        let result = APIHelper.mapValuesToQueryDictionary([
+            "query": query,
+            "limit": limit,
+            "name_gt": nameGt,
+            "role_type": roleType,
+            "include_global_roles": includeGlobalRoles
+        ])
+
+        #expect(result == ["query": "adm", "limit": "10", "role_type": "user"])
+    }
+
+    @Test("Bool values are converted to lowercase true/false")
+    func mapValuesToQueryDictionary_bool() {
+        let result = APIHelper.mapValuesToQueryDictionary([
+            "yes": true,
+            "no": false
+        ])
+
+        #expect(result == ["yes": "true", "no": "false"])
+    }
+
+    @Test("Array values are comma-joined")
+    func mapValuesToQueryDictionary_arrayJoined() {
+        let result = APIHelper.mapValuesToQueryDictionary([
+            "ids": ["a", "b", "c"]
+        ])
+
+        #expect(result == ["ids": "a,b,c"])
+    }
+
+    @Test("Empty or all-nil input returns nil")
+    func mapValuesToQueryDictionary_emptyReturnsNil() {
+        #expect(APIHelper.mapValuesToQueryDictionary([:]) == nil)
+        #expect(APIHelper.mapValuesToQueryDictionary([
+            "a": nil as String?,
+            "b": nil as Int?
+        ]) == nil)
+    }
 }


### PR DESCRIPTION
### 🔗 Issue Links

- [CHA-3808](https://linear.app/stream/issue/CHA-3808/openapi-swift-lang-endpoints-query-item-nil-handling)
- Consumer PR: GetStream/chat#14602

### 🎯 Goal

Generated Swift endpoints serialized nil query params as the literal string `<null>` (e.g. `?limit=<null>`) instead of omitting them from the URL.

### 📝 Summary

- Add `APIHelper.mapValuesToQueryDictionary(_ source: [String: Any?]) -> [String: String]?` — drops nil-valued keys and comma-joins collection values.
- Add unit tests: nil optionals dropped, `Bool` → `"true"`/`"false"`, `[String]` → CSV, empty/all-nil → `nil`.

### 🛠 Implementation

The chat OpenAPI Swift generator (GetStream/chat#14602) wraps generated `queryItems` dicts in this helper, passing scalars and `[String]` raw. `[String: Any?]` (not `[String: Any]`) preserves optionality so nil detection works via `filter { $0.value != nil }`; the `[String: String]?` return type conforms to `Encodable & Sendable` for `Endpoint.queryItems`. The existing `mapValuesToQueryItems` overloads are left untouched.

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

N/A

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
