### PR TITLE
[Enhancement]Make WebSocket ping interval configurable

### DIFF
--- a/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
+++ b/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
@@ -85,6 +85,9 @@ public class WebSocketClient: @unchecked Sendable {
     public var onWSConnectionEstablished: (() -> Void)?
     public var onConnected: (() -> Void)?
 
+    /// Creates a WebSocket client.
+    /// - Parameter pingInterval: The interval between WebSocket keep-alive pings.
+    ///   Defaults to 25 seconds.
     public init(
         sessionConfiguration: URLSessionConfiguration,
         eventDecoder: AnyEventDecoder,
@@ -94,6 +97,7 @@ public class WebSocketClient: @unchecked Sendable {
         connectRequest: URLRequest?,
         healthCheckBeforeConnected: Bool = false,
         requiresAuth: Bool = true,
+        pingInterval: TimeInterval = 25,
         pingRequestBuilder: (() -> any SendableEvent)? = nil
     ) {
         self.environment = environment
@@ -107,7 +111,8 @@ public class WebSocketClient: @unchecked Sendable {
         pingController = environment.createPingController(
             environment.timerType,
             engineQueue,
-            webSocketClientType
+            webSocketClientType,
+            pingInterval
         )
         pingController.pingRequestBuilder = pingRequestBuilder
         
@@ -192,7 +197,8 @@ public extension WebSocketClient {
         typealias CreatePingController = (
             _ timerType: TimerScheduling.Type,
             _ timerQueue: DispatchQueue,
-            _ webSocketClientType: WebSocketClientType
+            _ webSocketClientType: WebSocketClientType,
+            _ pingInterval: TimeInterval
         ) -> WebSocketPingController
 
         typealias CreateEngine = (

--- a/Sources/StreamCore/WebSocket/Client/WebSocketPingController.swift
+++ b/Sources/StreamCore/WebSocket/Client/WebSocketPingController.swift
@@ -21,13 +21,12 @@ public protocol HealthCheck: Event, Equatable {}
 /// The controller manages ping and pong timers. It sends ping periodically to keep a web socket connection alive.
 /// After ping is sent, a pong waiting timer is started, and if pong does not come, a forced disconnect is called.
 class WebSocketPingController {
-    /// The time interval to ping connection to keep it alive.
-    static let pingTimeInterval: TimeInterval = 25
     /// The time interval for pong timeout.
     static let pongTimeoutTimeInterval: TimeInterval = 3
     
     private let timerType: TimerScheduling.Type
     private let timerQueue: DispatchQueue
+    private let pingInterval: TimeInterval
     
     /// The timer used for scheduling `ping` calls
     private var pingTimerControl: RepeatingTimerControl?
@@ -53,11 +52,13 @@ class WebSocketPingController {
     init(
         timerType: TimerScheduling.Type,
         timerQueue: DispatchQueue,
-        webSocketClientType: WebSocketClientType
+        webSocketClientType: WebSocketClientType,
+        pingInterval: TimeInterval
     ) {
         self.timerType = timerType
         self.timerQueue = timerQueue
         self.webSocketClientType = webSocketClientType
+        self.pingInterval = pingInterval
     }
     
     /// `WebSocketClient` should call this when the connection state did change.
@@ -98,7 +99,10 @@ class WebSocketPingController {
     
     private func schedulePingTimerIfNeeded() {
         guard pingTimerControl == nil else { return }
-        pingTimerControl = timerType.scheduleRepeating(timeInterval: Self.pingTimeInterval, queue: timerQueue) { [weak self] in
+        pingTimerControl = timerType.scheduleRepeating(
+            timeInterval: pingInterval,
+            queue: timerQueue
+        ) { [weak self] in
             self?.sendPing()
         }
     }

--- a/Tests/StreamCoreTests/WebSockets/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Tests/StreamCoreTests/WebSockets/WebSocketClient/WebSocketClient_Tests.swift
@@ -23,6 +23,7 @@ final class WebSocketClient_Tests: XCTestCase, @unchecked Sendable {
     private var eventNotificationCenterMiddleware: EventMiddleware_Mock!
     
     private let connectURL = URL(string: "http://example.com/ws")!
+    private let pingInterval: TimeInterval = 5
     
     private let createdAt = Date()
     private lazy var healthCheckInfo = HealthCheckInfo(
@@ -50,7 +51,8 @@ final class WebSocketClient_Tests: XCTestCase, @unchecked Sendable {
             eventNotificationCenter: eventNotificationCenter,
             webSocketClientType: .coordinator,
             environment: environment,
-            connectRequest: URLRequest(url: connectURL)
+            connectRequest: URLRequest(url: connectURL),
+            pingInterval: pingInterval
         )
 
         connectionId = UUID().uuidString
@@ -240,6 +242,15 @@ final class WebSocketClient_Tests: XCTestCase, @unchecked Sendable {
 
         pingController.delegate?.sendPing()
         AssertAsync.willBeEqual(engine!.sendPing_calledCount, 1)
+    }
+
+    func test_webSocketPingController_usesConfiguredPingInterval() {
+        test_connectionFlow()
+        engine!.sendPing_calledCount = 0
+
+        time.run(numberOfSeconds: pingInterval + 1)
+
+        XCTAssertEqual(engine!.sendPing_calledCount, 1)
     }
 
     func test_pongReceived_callsPingController_pongReceived() {

--- a/Tests/StreamCoreTests/WebSockets/WebSocketClient/WebSocketPingController_Tests.swift
+++ b/Tests/StreamCoreTests/WebSockets/WebSocketClient/WebSocketPingController_Tests.swift
@@ -6,6 +6,7 @@
 import XCTest
 
 final class WebSocketPingController_Tests: XCTestCase, @unchecked Sendable {
+    private let pingInterval: TimeInterval = 5
     var time: VirtualTime!
     var pingController: WebSocketPingController!
     private var delegate: WebSocketPingController_Delegate!
@@ -17,7 +18,8 @@ final class WebSocketPingController_Tests: XCTestCase, @unchecked Sendable {
         pingController = .init(
             timerType: VirtualTimeTimer.self,
             timerQueue: .main,
-            webSocketClientType: .coordinator
+            webSocketClientType: .coordinator,
+            pingInterval: pingInterval
         )
 
         delegate = WebSocketPingController_Delegate()
@@ -36,21 +38,21 @@ final class WebSocketPingController_Tests: XCTestCase, @unchecked Sendable {
         assert(delegate.sendPing_calledCount == 0)
 
         // Check `sendPing` is not called when the connection is not connected
-        time.run(numberOfSeconds: WebSocketPingController.pingTimeInterval + 1)
+        time.run(numberOfSeconds: pingInterval + 1)
         XCTAssertEqual(delegate.sendPing_calledCount, 0)
 
         // Set the connection state as connected
         pingController.connectionStateDidChange(.connected(healthCheckInfo: HealthCheckInfo()))
 
         // Simulate time passed 3x pingTimeInterval (+1 for margin errors)
-        time.run(numberOfSeconds: 3 * (WebSocketPingController.pingTimeInterval + 1))
+        time.run(numberOfSeconds: 3 * (pingInterval + 1))
         XCTAssertEqual(delegate.sendPing_calledCount, 3)
 
         let oldPingCount = delegate.sendPing_calledCount
 
         // Set the connection state to not connected and check `sendPing` is no longer called
         pingController.connectionStateDidChange(.authenticating)
-        time.run(numberOfSeconds: 3 * (WebSocketPingController.pingTimeInterval + 1))
+        time.run(numberOfSeconds: 3 * (pingInterval + 1))
         XCTAssertEqual(delegate.sendPing_calledCount, oldPingCount)
     }
 


### PR DESCRIPTION
### 🎯 Goal

Allow product SDKs to configure their WebSocket keep-alive cadence. Stream Video requires a 5-second SFU ping interval because the existing fixed 25-second interval exceeds its 15-second health timeout and causes unnecessary call reconnections.

### 📝 Summary

- Add a configurable `pingInterval` to `WebSocketClient`.
- Preserve the existing 25-second default.
- Add unit-test coverage for custom intervals.

### 🛠 Implementation

`WebSocketClient` forwards the configured interval to `WebSocketPingController`, which uses it when scheduling its repeating timer. Existing consumers retain the current behavior through the default value.

### 🎨 Showcase

Not applicable.

### 🧪 Manual Testing Notes

Configure Stream Video’s SFU WebSocket with a 5-second interval and verify that an active call continues receiving health-check responses without reconnecting.

Automated verification:
- 19 focused WebSocket tests passed.
- SwiftFormat and SwiftLint passed.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo