### PR TITLE
[Enhancement]Make logger unchecked sendable

### DIFF
--- a/Sources/StreamCore/Logger/Logger.swift
+++ b/Sources/StreamCore/Logger/Logger.swift
@@ -436,7 +436,7 @@ public enum LogConfig {
 }
 
 /// Entity used for logging messages.
-open class Logger {
+open class Logger: @unchecked Sendable {
     /// Identifier of the Logger. Will be visible if a destination has `showIdentifiers` enabled.
     public let identifier: String
     

--- a/Tests/StreamCoreTests/Logger/Logger_Tests.swift
+++ b/Tests/StreamCoreTests/Logger/Logger_Tests.swift
@@ -2,10 +2,37 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import Foundation
 @testable import StreamCore
 import Testing
 
 struct Logger_Tests {
+    @Test func concurrentLoggingProcessesAllMessages() async throws {
+        let iterations = 200
+        let destination = CapturingDestination()
+        let logger = Logger(identifier: "test", destinations: [destination])
+
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<iterations {
+                group.addTask {
+                    logger.debug("message_\(index)")
+                }
+            }
+        }
+
+        let deadline = Date().addingTimeInterval(5)
+        while destination.processedCount < iterations, Date() < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(destination.processedCount == iterations)
+        #expect(
+            destination.recordedThreadNames.contains {
+                $0.contains("LoggerQueue")
+            } == false
+        )
+    }
+
     // MARK: - Concurrent Logger Invalidation Tests
 
     @Test func concurrentLoggerInvalidation() async throws {
@@ -139,5 +166,81 @@ struct Logger_Tests {
     
     private func resetLogConfig() {
         LogConfig.reset()
+    }
+}
+
+private final class CapturingDestination: BaseLogDestination, @unchecked Sendable {
+    private var logDetails: [LogDetails] = []
+    private let lock = NSLock()
+
+    init() {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        super.init(
+            identifier: UUID().uuidString,
+            level: .debug,
+            subsystems: .all,
+            showDate: false,
+            dateFormatter: formatter,
+            formatters: [],
+            showLevel: false,
+            showIdentifier: false,
+            showThreadName: true,
+            showFileName: false,
+            showLineNumber: false,
+            showFunctionName: false
+        )
+    }
+
+    @available(*, unavailable)
+    required init(
+        identifier: String,
+        level: LogLevel,
+        subsystems: LogSubsystem,
+        showDate: Bool,
+        dateFormatter: DateFormatter,
+        formatters: [LogFormatter],
+        showLevel: Bool,
+        showIdentifier: Bool,
+        showThreadName: Bool,
+        showFileName: Bool,
+        showLineNumber: Bool,
+        showFunctionName: Bool
+    ) {
+        super.init(
+            identifier: identifier,
+            level: level,
+            subsystems: subsystems,
+            showDate: showDate,
+            dateFormatter: dateFormatter,
+            formatters: formatters,
+            showLevel: showLevel,
+            showIdentifier: showIdentifier,
+            showThreadName: showThreadName,
+            showFileName: showFileName,
+            showLineNumber: showLineNumber,
+            showFunctionName: showFunctionName
+        )
+        fatalError("Unsupported initializer")
+    }
+
+    override func process(logDetails: LogDetails) {
+        lock.lock()
+        self.logDetails.append(logDetails)
+        lock.unlock()
+    }
+
+    override func write(message: String) {}
+
+    var processedCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return logDetails.count
+    }
+
+    var recordedThreadNames: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return logDetails.map(\.threadName)
     }
 }


### PR DESCRIPTION
### 🔗 Issue Links

- Related to https://linear.app/stream/issue/IOS-1816
- Unblocks https://github.com/GetStream/stream-video-swift/pull/1178

### 🎯 Goal

Allow `Logger` to be safely captured by `@Sendable` closures and restore the concurrency contract previously provided by StreamVideo’s logger.

### 📝 Summary

- Add `@unchecked Sendable` conformance to `Logger`.
- Add a Swift Testing concurrency regression test.
- Verify concurrent logging processes every message and preserves caller thread metadata.

### 🛠 Implementation

`Logger` now declares `@unchecked Sendable` because it is a reference type that supports concurrent logging through its serialized delivery queue.

The regression test uses a task group to log 200 messages concurrently and verifies that every message is processed.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo