### PR TITLE
[Enhancement] Expose LogConfig level publisher

### DIFF
--- a/Sources/StreamCore/Logger/Logger.swift
+++ b/Sources/StreamCore/Logger/Logger.swift
@@ -2,6 +2,7 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 import Foundation
 
 public var log: Logger {
@@ -251,9 +252,17 @@ public enum LogConfig {
                 $0.level = newValue
                 $0.invalidateLogger()
             }
+            Self.levelSubject.send(newValue)
         }
     }
-    
+
+    private nonisolated(unsafe) static let levelSubject = CurrentValueSubject<LogLevel, Never>(_state.value.level)
+
+    /// Publishes the current log level and all subsequent changes.
+    public static var levelPublisher: AnyPublisher<LogLevel, Never> {
+        levelSubject.eraseToAnyPublisher()
+    }
+
     /// Date formatter for the logger. Defaults to ISO8601
     public static var dateFormatter: DateFormatter {
         get {
@@ -432,6 +441,7 @@ public enum LogConfig {
     
     static func reset() {
         _state.withLock { $0 = State() }
+        levelSubject.send(level)
     }
 }
 

--- a/Tests/StreamCoreTests/Logger/Logger_Tests.swift
+++ b/Tests/StreamCoreTests/Logger/Logger_Tests.swift
@@ -2,10 +2,12 @@
 // Copyright © 2026 Stream.io Inc. All rights reserved.
 //
 
+import Combine
 import Foundation
 @testable import StreamCore
 import Testing
 
+@Suite(.serialized)
 struct Logger_Tests {
     @Test func concurrentLoggingProcessesAllMessages() async throws {
         let iterations = 200
@@ -31,6 +33,22 @@ struct Logger_Tests {
                 $0.contains("LoggerQueue")
             } == false
         )
+    }
+
+    @Test func levelPublisherEmitsCurrentLevelAndChanges() {
+        resetLogConfig()
+        defer { resetLogConfig() }
+        let receivedLevels = AllocatedUnfairLock<[LogLevel]>([])
+        let cancellable = LogConfig.levelPublisher.sink { level in
+            #expect(LogConfig.level == level)
+            receivedLevels.withLock { $0.append(level) }
+        }
+
+        withExtendedLifetime(cancellable) {
+            LogConfig.level = .debug
+        }
+
+        #expect(receivedLevels.value == [.error, .debug])
     }
 
     // MARK: - Concurrent Logger Invalidation Tests


### PR DESCRIPTION
### 🔗 Issue Links

Related: https://linear.app/stream/issue/IOS-1814/restore-webrtc-internal-log-severity-sync-with-logconfiglevel

### 🎯 Goal

Allow StreamCore consumers to observe `LogConfig.level` changes without duplicating logging configuration.

This enables StreamVideo to keep WebRTC internal-log severity synchronized with the configured SDK log level.

### 📝 Summary

- Expose `LogConfig.levelPublisher`.
- Back the publisher with a private `CurrentValueSubject`.
- Publish level changes after updating the locked configuration state.
- Keep the publisher synchronized when `LogConfig` resets.
- Add focused publisher coverage.

### 🛠 Implementation

`LogConfig` retains ownership of its lock-backed configuration state. A private `CurrentValueSubject` publishes the current level and subsequent assignments through a public, type-erased `AnyPublisher`.

Events are emitted after releasing the configuration lock, allowing subscribers to safely read `LogConfig` without reentrancy deadlocks.

### 🎨 Showcase

Not applicable.

### 🧪 Manual Testing Notes

No manual testing is required.

The focused Logger test suite passes. SwiftFormat, SwiftLint, and `git diff --check` also pass.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo