### PR TITLE
[Enhancement]Extend disposableBag api

### DIFF
--- a/Sources/StreamCore/Utils/DisposableBag.swift
+++ b/Sources/StreamCore/Utils/DisposableBag.swift
@@ -24,9 +24,11 @@ public final class DisposableBag: @unchecked Sendable {
             }
         }
 
-        func remove(_ key: String) {
+        func remove(_ key: String, cancel: Bool) {
             queue.sync {
-                storage[key]?.cancel()
+                if cancel {
+                    storage[key]?.cancel()
+                }
                 storage[key] = nil
             }
         }
@@ -53,7 +55,7 @@ public final class DisposableBag: @unchecked Sendable {
     }
 
     public func remove(_ key: String) {
-        storage.remove(key)
+        storage.remove(key, cancel: true)
     }
 
     public func removeAll() {
@@ -61,6 +63,10 @@ public final class DisposableBag: @unchecked Sendable {
     }
 
     public var isEmpty: Bool { storage.isEmpty }
+
+    public func completed(_ key: String) {
+        storage.remove(key, cancel: false)
+    }
 }
 
 extension AnyCancellable {

--- a/Tests/StreamCoreTests/Utils/DisposableBag_Tests.swift
+++ b/Tests/StreamCoreTests/Utils/DisposableBag_Tests.swift
@@ -1,0 +1,35 @@
+//
+// Copyright © 2026 Stream.io Inc. All rights reserved.
+//
+
+import Combine
+@testable import StreamCore
+import XCTest
+
+final class DisposableBag_Tests: XCTestCase, @unchecked Sendable {
+    func test_completed_removesCancellableWithoutCancelling() {
+        let subject = DisposableBag()
+        var wasCancelled = false
+        let cancellable = AnyCancellable { wasCancelled = true }
+
+        subject.insert(cancellable, with: "task")
+        subject.completed("task")
+
+        XCTAssertTrue(subject.isEmpty)
+        XCTAssertFalse(wasCancelled)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    func test_remove_removesAndCancelsCancellable() {
+        let subject = DisposableBag()
+        var wasCancelled = false
+        let cancellable = AnyCancellable { wasCancelled = true }
+
+        subject.insert(cancellable, with: "task")
+        subject.remove("task")
+
+        XCTAssertTrue(subject.isEmpty)
+        XCTAssertTrue(wasCancelled)
+        withExtendedLifetime(cancellable) {}
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Add the missing non-cancelling cleanup path needed for StreamVideo to replace its duplicate `DisposableBag` with StreamCore's implementation.

### 📝 Summary

- Add `DisposableBag.completed(_:)`.
- Preserve the cancelling behavior of `remove(_:)` and `removeAll()`.
- Add two focused tests covering cancelling and non-cancelling removal.

### 🛠 Implementation

`completed(_:)` removes an entry without invoking its cancellation handler, representing work that has already finished. In contrast, `remove(_:)` and `removeAll()` continue to cancel entries before removing them.

Both removal paths use the existing queue-synchronized storage mutation, preserving `DisposableBag`'s thread-safety guarantees.

This behavioral parity allows StreamVideo to use StreamCore's `DisposableBag` instead of maintaining a duplicate implementation.

### 🎨 Showcase

Not applicable — no UI changes.

### 🧪 Manual Testing Notes

Automated validation completed:

- 2/2 focused `DisposableBag` tests passed.
- iOS build passed.
- SwiftFormat passed.
- `git diff --check` passed.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo