### PR TITLE
[Enhancement]Add configurable WebSocket close code provider

### DIFF
--- a/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
+++ b/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
@@ -7,8 +7,26 @@ import Foundation
 
 /// Describes why a client-initiated WebSocket close is requested.
 public enum WebSocketCloseContext: Equatable, Sendable {
+    /// Closes the current socket because a disconnection was requested or
+    /// detected.
+    ///
+    /// The source lets a provider distinguish cases such as a user request,
+    /// automatic recovery, or a failed health check and select the appropriate
+    /// close code.
     case disconnection(source: WebSocketConnectionState.DisconnectionSource)
+
+    /// Closes the current socket so it can be replaced with new connection
+    /// settings while the higher-level operation continues.
+    ///
+    /// For example, Stream Video uses this context when replacing its SFU
+    /// signaling socket after receiving an updated WebSocket configuration.
     case reconfiguration
+
+    /// Closes the current socket with a protocol-specific code requested by the
+    /// caller.
+    ///
+    /// This supports integrations that already know the required close code.
+    /// The provider receives that code and may preserve or override it.
     case explicit(
         code: URLSessionWebSocketTask.CloseCode,
         source: WebSocketConnectionState.DisconnectionSource

--- a/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
+++ b/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
@@ -5,6 +5,44 @@
 import Combine
 import Foundation
 
+/// Describes why a client-initiated WebSocket close is requested.
+public enum WebSocketCloseContext: Equatable, Sendable {
+    case disconnection(source: WebSocketConnectionState.DisconnectionSource)
+    case reconfiguration
+    case explicit(
+        code: URLSessionWebSocketTask.CloseCode,
+        source: WebSocketConnectionState.DisconnectionSource
+    )
+
+    var disconnectionSource: WebSocketConnectionState.DisconnectionSource {
+        switch self {
+        case let .disconnection(source), let .explicit(_, source):
+            return source
+        case .reconfiguration:
+            return .userInitiated
+        }
+    }
+}
+
+/// Provides the close code for a client-initiated WebSocket close.
+public protocol WebSocketCloseCodeProviding: Sendable {
+    func closeCode(for context: WebSocketCloseContext) -> URLSessionWebSocketTask.CloseCode
+}
+
+/// Preserves the default WebSocket close-code behavior.
+public struct DefaultWebSocketCloseCodeProvider: WebSocketCloseCodeProviding {
+    public init() {}
+
+    public func closeCode(for context: WebSocketCloseContext) -> URLSessionWebSocketTask.CloseCode {
+        switch context {
+        case let .explicit(code, _):
+            return code
+        case .disconnection, .reconfiguration:
+            return .normalClosure
+        }
+    }
+}
+
 public class WebSocketClient: @unchecked Sendable {
     /// The notification center `WebSocketClient` uses to send notifications about incoming events.
     public let eventNotificationCenter: EventNotificationCenter
@@ -69,6 +107,7 @@ public class WebSocketClient: @unchecked Sendable {
     private let environment: Environment
 
     private let webSocketClientType: WebSocketClientType
+    private let closeCodeProvider: any WebSocketCloseCodeProviding
 
     let pingController: WebSocketPingController
 
@@ -98,6 +137,7 @@ public class WebSocketClient: @unchecked Sendable {
         healthCheckBeforeConnected: Bool = false,
         requiresAuth: Bool = true,
         pingInterval: TimeInterval = 25,
+        closeCodeProvider: any WebSocketCloseCodeProviding = DefaultWebSocketCloseCodeProvider(),
         pingRequestBuilder: (() -> any SendableEvent)? = nil
     ) {
         self.environment = environment
@@ -108,6 +148,7 @@ public class WebSocketClient: @unchecked Sendable {
         self.eventNotificationCenter = eventNotificationCenter
         self.healthCheckBeforeConnected = healthCheckBeforeConnected
         self.requiresAuth = requiresAuth
+        self.closeCodeProvider = closeCodeProvider
         pingController = environment.createPingController(
             environment.timerType,
             engineQueue,
@@ -148,16 +189,46 @@ public class WebSocketClient: @unchecked Sendable {
         }
     }
 
-    /// Disconnects the web socket.
+    /// Disconnects using the existing close-code-based API.
     ///
-    /// Calling this function has no effect, if the connection is in an inactive state.
-    /// - Parameter source: Additional information about the source of the disconnection. Default value is `.userInitiated`.
+    /// The close-code provider receives an
+    /// ``WebSocketCloseContext/explicit(code:source:)`` context and chooses the
+    /// final close code. Prefer ``disconnect(context:completion:)`` for new
+    /// code that can describe why the socket is closing without selecting a
+    /// close code.
+    ///
+    /// - Parameters:
+    ///   - code: The requested close code. The provider may return a different
+    ///     code.
+    ///   - source: The source recorded in the connection state.
+    ///   - completion: Called after pending batched events are processed.
     public func disconnect(
         code: URLSessionWebSocketTask.CloseCode = .normalClosure,
         source: WebSocketConnectionState.DisconnectionSource = .userInitiated,
         completion: @Sendable @escaping () -> Void
     ) {
-        connectionState = .disconnecting(source: source)
+        disconnect(
+            context: .explicit(code: code, source: source),
+            completion: completion
+        )
+    }
+
+    /// Disconnects by describing why the socket is closing.
+    ///
+    /// Use this API for new integrations. The close-code provider receives the
+    /// context and chooses the final close code. For example, use
+    /// ``WebSocketCloseContext/reconfiguration`` when replacing a socket so the
+    /// provider can select a product-specific reconfiguration code.
+    ///
+    /// - Parameters:
+    ///   - context: The reason for closing the socket.
+    ///   - completion: Called after pending batched events are processed.
+    public func disconnect(
+        context: WebSocketCloseContext,
+        completion: @Sendable @escaping () -> Void
+    ) {
+        connectionState = .disconnecting(source: context.disconnectionSource)
+        let code = closeCodeProvider.closeCode(for: context)
         engineQueue.async { [engine, eventsBatcher] in
             engine?.disconnect(with: code)
 
@@ -165,13 +236,21 @@ public class WebSocketClient: @unchecked Sendable {
         }
     }
 
+    /// Asynchronously disconnects with the given disconnection source.
+    ///
+    /// The close-code provider receives a
+    /// ``WebSocketCloseContext/disconnection(source:)`` context and chooses the
+    /// final close code. The call returns after pending batched events are
+    /// processed, not after the remote peer acknowledges the closure.
+    ///
+    /// - Parameter source: The source recorded in the connection state.
     public func disconnect(source: WebSocketConnectionState.DisconnectionSource = .userInitiated) async {
         await withCheckedContinuation { [weak self] continuation in
             guard let self else {
                 continuation.resume()
                 return
             }
-            disconnect {
+            disconnect(context: .disconnection(source: source)) {
                 continuation.resume()
             }
         }
@@ -360,7 +439,7 @@ extension WebSocketClient: WebSocketPingControllerDelegate {
 
     func disconnectOnNoPongReceived() {
         log.debug("disconnecting from \(String(describing: connectRequest?.url))", subsystems: .webSocket)
-        disconnect(source: .noPongReceived) {
+        disconnect(context: .disconnection(source: .noPongReceived)) {
             log.debug("Websocket is disconnected because of no pong received", subsystems: .webSocket)
         }
     }

--- a/Tests/StreamCoreTests/Mocks/WebSocketEngine_Mock.swift
+++ b/Tests/StreamCoreTests/Mocks/WebSocketEngine_Mock.swift
@@ -17,6 +17,7 @@ final class WebSocketEngine_Mock: WebSocketEngine, @unchecked Sendable {
 
     /// How many times was `disconnect()` called
     @Atomic var disconnect_calledCount = 0
+    @Atomic var disconnect_closeCode: URLSessionWebSocketTask.CloseCode?
 
     /// How many times was `sendPing()` called
     @Atomic var sendPing_calledCount = 0
@@ -40,6 +41,7 @@ final class WebSocketEngine_Mock: WebSocketEngine, @unchecked Sendable {
     }
 
     func disconnect(with code: URLSessionWebSocketTask.CloseCode) {
+        disconnect_closeCode = code
         disconnect_calledCount += 1
     }
 

--- a/Tests/StreamCoreTests/WebSockets/WebSocketClient/WebSocketClient_Tests.swift
+++ b/Tests/StreamCoreTests/WebSockets/WebSocketClient/WebSocketClient_Tests.swift
@@ -150,6 +150,54 @@ final class WebSocketClient_Tests: XCTestCase, @unchecked Sendable {
 
         // Assert disconnect is called
         AssertAsync.willBeEqual(engine!.disconnect_calledCount, 1)
+        XCTAssertEqual(engine!.disconnect_closeCode, .normalClosure)
+    }
+
+    func test_disconnect_withExplicitCode_usesCloseCodeProviderDecision() {
+        let providerCloseCode = URLSessionWebSocketTask.CloseCode(rawValue: 4001)!
+        let requestedCloseCode = URLSessionWebSocketTask.CloseCode(rawValue: 4002)!
+        let closeCodeProvider = setUpWebSocketClient(closeCode: providerCloseCode)
+
+        webSocketClient.disconnect(
+            code: requestedCloseCode,
+            source: .userInitiated
+        ) {}
+
+        AssertAsync.willBeEqual(engine!.disconnect_calledCount, 1)
+        XCTAssertEqual(engine!.disconnect_closeCode, providerCloseCode)
+        XCTAssertEqual(
+            closeCodeProvider.receivedContext,
+            .explicit(code: requestedCloseCode, source: .userInitiated)
+        )
+    }
+
+    func test_disconnect_withExplicitCode_defaultProviderUsesRequestedCode() {
+        let requestedCloseCode = URLSessionWebSocketTask.CloseCode(rawValue: 4002)!
+        webSocketClient.connect()
+        AssertAsync.willBeEqual(engine!.connect_calledCount, 1)
+
+        webSocketClient.disconnect(
+            code: requestedCloseCode,
+            source: .userInitiated
+        ) {}
+
+        AssertAsync.willBeEqual(engine!.disconnect_calledCount, 1)
+        XCTAssertEqual(engine!.disconnect_closeCode, requestedCloseCode)
+    }
+
+    func test_disconnect_withReconfigurationContext_usesCloseCodeProviderDecision() {
+        let providerCloseCode = URLSessionWebSocketTask.CloseCode(rawValue: 4002)!
+        let closeCodeProvider = setUpWebSocketClient(closeCode: providerCloseCode)
+
+        webSocketClient.disconnect(context: .reconfiguration) {}
+
+        AssertAsync.willBeEqual(engine!.disconnect_calledCount, 1)
+        XCTAssertEqual(
+            webSocketClient.connectionState,
+            .disconnecting(source: .userInitiated)
+        )
+        XCTAssertEqual(engine!.disconnect_closeCode, providerCloseCode)
+        XCTAssertEqual(closeCodeProvider.receivedContext, .reconfiguration)
     }
 
     func test_whenConnectedAndEngineDisconnectsWithServerError_itIsTreatedAsServerInitiatedDisconnect() {
@@ -277,6 +325,24 @@ final class WebSocketClient_Tests: XCTestCase, @unchecked Sendable {
             Assert.willBeEqual(self.webSocketClient.connectionState, .disconnecting(source: .noPongReceived))
             Assert.willBeEqual(self.engine!.disconnect_calledCount, 1)
         }
+        XCTAssertEqual(engine!.disconnect_closeCode, .normalClosure)
+    }
+
+    func test_webSocketPingController_disconnectOnNoPongReceived_usesCloseCodeProvider() {
+        let providerCloseCode = URLSessionWebSocketTask.CloseCode(rawValue: 4001)!
+        let closeCodeProvider = setUpWebSocketClient(closeCode: providerCloseCode)
+
+        pingController.delegate?.disconnectOnNoPongReceived()
+
+        AssertAsync {
+            Assert.willBeEqual(self.webSocketClient.connectionState, .disconnecting(source: .noPongReceived))
+            Assert.willBeEqual(self.engine!.disconnect_calledCount, 1)
+        }
+        XCTAssertEqual(engine!.disconnect_closeCode, providerCloseCode)
+        XCTAssertEqual(
+            closeCodeProvider.receivedContext,
+            .disconnection(source: .noPongReceived)
+        )
     }
 
     // MARK: - Event handling tests
@@ -370,6 +436,41 @@ final class WebSocketClient_Tests: XCTestCase, @unchecked Sendable {
             self.webSocketClient.initialize()
             self.webSocketClient.connect()
         })
+    }
+
+    private func setUpWebSocketClient(
+        closeCode: URLSessionWebSocketTask.CloseCode
+    ) -> WebSocketCloseCodeProvider_Mock {
+        let closeCodeProvider = WebSocketCloseCodeProvider_Mock(closeCode: closeCode)
+        var environment = WebSocketClient.Environment.mock
+        environment.timerType = VirtualTimeTimer.self
+        webSocketClient = WebSocketClient(
+            sessionConfiguration: .ephemeral,
+            eventDecoder: decoder,
+            eventNotificationCenter: eventNotificationCenter,
+            webSocketClientType: .coordinator,
+            environment: environment,
+            connectRequest: URLRequest(url: connectURL),
+            pingInterval: pingInterval,
+            closeCodeProvider: closeCodeProvider
+        )
+        webSocketClient.connect()
+        AssertAsync.willBeEqual(engine!.connect_calledCount, 1)
+        return closeCodeProvider
+    }
+}
+
+private final class WebSocketCloseCodeProvider_Mock: WebSocketCloseCodeProviding, @unchecked Sendable {
+    private let closeCode: URLSessionWebSocketTask.CloseCode
+    private(set) var receivedContext: WebSocketCloseContext?
+
+    init(closeCode: URLSessionWebSocketTask.CloseCode) {
+        self.closeCode = closeCode
+    }
+
+    func closeCode(for context: WebSocketCloseContext) -> URLSessionWebSocketTask.CloseCode {
+        receivedContext = context
+        return closeCode
     }
 }
 


### PR DESCRIPTION
### 🎯 Goal

Allow StreamCore integrators to choose WebSocket close codes based on why a socket is being closed, without introducing product-specific knowledge into StreamCore.

The default behavior remains unchanged for existing integrations.

### 📝 Summary

- Add semantic WebSocket close contexts.
- Add an injectable close-code provider.
- Preserve the existing close-code-based disconnect API.
- Route async and no-pong disconnections through the provider.
- Document the intended usage and internal close-code behavior of each disconnect API.
- Add unit tests covering default and custom close-code decisions.

### 🛠 Implementation

`WebSocketCloseContext` describes the reason for closing a socket:

- `.disconnection(source:)` for regular disconnections.
- `.reconfiguration` when replacing or reconfiguring a socket.
- `.explicit(code:source:)` for compatibility with callers that already provide a close code.

`WebSocketClient` accepts a `WebSocketCloseCodeProviding` implementation during initialization. Before disconnecting the underlying engine, it passes the close context to the provider and uses the returned close code.

`DefaultWebSocketCloseCodeProvider` preserves the previous behavior:

- Regular disconnections and reconfiguration use `.normalClosure`.
- Explicitly requested close codes remain unchanged.

The existing `disconnect(code:source:completion:)` API remains source-compatible. New integrations can use `disconnect(context:completion:)` to communicate intent without selecting a product-specific close code.

### 🎨 Showcase

Not applicable. This change has no UI impact.

### 🧪 Manual Testing Notes

No manual testing is required. The behavior is covered by focused `WebSocketClient` unit tests for:

- Default normal closure.
- Explicit close codes.
- Custom provider decisions.
- Reconfiguration.
- No-pong disconnections.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo