### PR TITLE
Expose WebSocket connection state and terminal error events

### DIFF
--- a/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
+++ b/Sources/StreamCore/WebSocket/Client/WebSocketClient.swift
@@ -86,8 +86,15 @@ public class WebSocketClient: @unchecked Sendable {
         }
     }
 
-    let connectionSubject = PassthroughSubject<WebSocketConnectionState, Never>()
+    private let connectionSubject = CurrentValueSubject<
+        WebSocketConnectionState,
+        Never
+    >(.initialized)
     public let eventSubject = PassthroughSubject<Event, Never>()
+
+    public var connectionStatePublisher: AnyPublisher<WebSocketConnectionState, Never> {
+        connectionSubject.eraseToAnyPublisher()
+    }
 
     public weak var connectionStateDelegate: ConnectionStateDelegate?
 
@@ -383,6 +390,8 @@ extension WebSocketClient: WebSocketEngineDelegate {
 
         if let error = event.error() {
             log.error("Received an error webSocket event.", subsystems: .webSocket, error: error)
+            // Publish before disconnecting so observers receive the terminal event.
+            eventSubject.send(event)
             connectionState = .disconnecting(source: .serverInitiated(error: ClientError(with: error)))
             return
         } else {


### PR DESCRIPTION
# Description

## Summary

- Expose a public `connectionStatePublisher` from `WebSocketClient`.
- Replay the current connection state to new subscribers.
- Publish terminal error events before transitioning the socket to a disconnected state.

## Motivation

Consumers need to observe the current WebSocket connection state without maintaining a separate delegate-backed state publisher.

Terminal error events were previously consumed internally while disconnecting, preventing event subscribers from receiving the server-provided error payload.
