### PR TITLE
[Enhancement]Prevent WebSocket reconnection with expired tokens

### DIFF
--- a/Sources/StreamCore/WebSocket/Client/ConnectionStatus.swift
+++ b/Sources/StreamCore/WebSocket/Client/ConnectionStatus.swift
@@ -42,7 +42,9 @@ public extension ConnectionStatus {
             self = .disconnecting
             
         case let .disconnected(source):
-            let isWaitingForReconnect = webSocketConnectionState.isAutomaticReconnectionEnabled
+            let isWaitingForReconnect =
+                webSocketConnectionState.isAutomaticReconnectionEnabled
+                    || webSocketConnectionState.requiresTokenRefresh
             
             self = isWaitingForReconnect ? .connecting : .disconnected(error: source.serverError)
         }
@@ -112,6 +114,15 @@ public enum WebSocketConnectionState: Equatable, Sendable {
         return true
     }
     
+    /// Returns `true` when a fresh token must be installed before reconnecting.
+    public var requiresTokenRefresh: Bool {
+        guard case let .disconnected(source) = self else {
+            return false
+        }
+
+        return source.serverError?.isTokenExpiredError == true
+    }
+
     /// Returns `true` is the state requires and allows automatic reconnection.
     public var isAutomaticReconnectionEnabled: Bool {
         guard case let .disconnected(source) = self else { return false }
@@ -125,14 +136,15 @@ public enum WebSocketConnectionState: Equatable, Sendable {
             }
             
             if let serverInitiatedError = clientError?.apiError {
-                if serverInitiatedError.isInvalidTokenError {
-                    // Don't reconnect on invalid token errors
+                if serverInitiatedError.isInvalidTokenError
+                    || serverInitiatedError.isTokenExpiredError {
+                    // A new token must be installed before reconnecting.
+                    // Retrying here can race the product's token refresh.
                     return false
                 }
                 
-                if serverInitiatedError.isClientError && !serverInitiatedError.isTokenExpiredError {
-                    // Don't reconnect on client side errors unless it is an expired token
-                    // Expired tokens return 401, so it is considered client error.
+                if serverInitiatedError.isClientError {
+                    // Don't reconnect on client-side errors.
                     return false
                 }
             }

--- a/Tests/StreamCoreTests/WebSockets/Client/ConnectionStatus_Tests.swift
+++ b/Tests/StreamCoreTests/WebSockets/Client/ConnectionStatus_Tests.swift
@@ -17,6 +17,14 @@ final class ConnectionStatus_Tests: XCTestCase {
             )
         )
 
+        let expiredTokenError = ClientError(
+            with: APIError(
+                code: StreamErrorCode.expiredToken,
+                message: .unique,
+                statusCode: 401
+            )
+        )
+
         let pairs: [(WebSocketConnectionState, ConnectionStatus)] = [
             (.initialized, .initialized),
             (.connecting, .connecting),
@@ -26,6 +34,7 @@ final class ConnectionStatus_Tests: XCTestCase {
             (.disconnected(source: .serverInitiated(error: nil)), .connecting),
             (.disconnected(source: .serverInitiated(error: testError)), .connecting),
             (.disconnected(source: .serverInitiated(error: invalidTokenError)), .disconnected(error: invalidTokenError)),
+            (.disconnected(source: .serverInitiated(error: expiredTokenError)), .connecting),
             (.connected(healthCheckInfo: HealthCheckInfo(connectionId: .unique)), .connected),
             (.disconnecting(source: .noPongReceived), .disconnecting),
             (.disconnecting(source: .serverInitiated(error: testError)), .disconnecting),

--- a/Tests/StreamCoreTests/WebSockets/WebSocketClient/WebSocketConnectionState_Tests.swift
+++ b/Tests/StreamCoreTests/WebSockets/WebSocketClient/WebSocketConnectionState_Tests.swift
@@ -106,6 +106,23 @@ final class WebSocketConnectionState_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertFalse(state.isAutomaticReconnectionEnabled)
     }
 
+    func test_expiredToken_requiresRefreshAndDisablesAutomaticReconnection() {
+        let expiredTokenError = APIError(
+            code: StreamErrorCode.expiredToken,
+            message: .unique,
+            statusCode: 401
+        )
+
+        let state: WebSocketConnectionState = .disconnected(
+            source: .serverInitiated(
+                error: ClientError(with: expiredTokenError)
+            )
+        )
+
+        XCTAssertTrue(state.requiresTokenRefresh)
+        XCTAssertFalse(state.isAutomaticReconnectionEnabled)
+    }
+
     func test_isAutomaticReconnectionEnabled_whenDisconnectedByServerWithClientError_returnsFalse() {
         // Create client error
         let clientError = APIError(


### PR DESCRIPTION
## Summary

Separates token-refresh recovery from automatic WebSocket reconnection.

When a WebSocket disconnects because its token expired, StreamCore now waits for the owning SDK to refresh the token and reconnect explicitly instead of retrying with the existing credentials.

## Motivation

An expired token was previously considered automatically reconnectable. This allowed `DefaultConnectionRecoveryHandler` to call `connect()` while StreamChat or StreamVideo was still refreshing the token.

That created a race where the WebSocket could reconnect using stale credentials.

## Changes

- Add `WebSocketConnectionState.requiresTokenRefresh`.
- Disable automatic reconnection for expired tokens.
- Preserve the existing invalid-token reconnection behavior.
- Keep `ConnectionStatus` as `.connecting` while token refresh is required.
- Add tests covering expired-token classification and connection-status mapping.

## Recovery contract

- StreamCore automatically handles network, system, and health-check failures.
- Product SDKs handle authentication recovery.
- After successfully refreshing the token, the product SDK explicitly calls `connect()`.
