### PR TITLE
Restore InternetConnectionProtocol status access

### DIFF
--- a/Sources/StreamCore/Utils/InternetConnection.swift
+++ b/Sources/StreamCore/Utils/InternetConnection.swift
@@ -213,6 +213,9 @@ extension InternetConnection {
 
 /// A protocol defining the interface for internet connection monitoring.
 public protocol InternetConnectionProtocol {
+    /// The current Internet connection status.
+    var status: InternetConnectionStatus { get }
+
     /// A publisher that emits the current internet connection status.
     ///
     /// This publisher never fails and continuously updates with the latest

--- a/Tests/StreamCoreTests/Utils/InternetConnection_Tests.swift
+++ b/Tests/StreamCoreTests/Utils/InternetConnection_Tests.swift
@@ -32,6 +32,12 @@ final class InternetConnection_Tests: XCTestCase, @unchecked Sendable {
         XCTAssertTrue(monitor.delegate === internetConnection)
     }
 
+    func test_internetConnectionProtocol_exposesCurrentStatus() {
+        let subject: any InternetConnectionProtocol = internetConnection
+
+        XCTAssertEqual(subject.status, monitor.status)
+    }
+
     func test_internetConnection_postsStatusAndAvailabilityNotifications_whenAvailabilityChanges() {
         // Set unavailable status
         monitor.status = .unavailable


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Restore synchronous access to the current internet connection status through
`InternetConnectionProtocol`.

### 📝 Summary

- Add the existing `InternetConnection.status` property to the protocol.
- Cover access through a protocol existential with a regression test.

### 🛠 Implementation

Adds a read-only `status` requirement. `InternetConnection` already provides
the implementation, so no new state or behavior is introduced.

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

Automated tests cover the protocol-level API. No manual QA is required.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
