### PR TITLE
Fix repeating timer initial delay

### DIFF
--- a/Sources/StreamCore/Utils/Timers.swift
+++ b/Sources/StreamCore/Utils/Timers.swift
@@ -125,7 +125,7 @@ private class RepeatingTimer: RepeatingTimerControl, @unchecked Sendable {
 
     init(timeInterval: TimeInterval, queue: DispatchQueue, onFire: @escaping () -> Void) {
         timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now() + .milliseconds(Int(timeInterval)), repeating: timeInterval, leeway: .seconds(1))
+        timer.schedule(deadline: .now() + timeInterval, repeating: timeInterval, leeway: .seconds(1))
         timer.setEventHandler(handler: onFire)
     }
 

--- a/Tests/StreamCoreTests/Utils/RepeatingTimer_Tests.swift
+++ b/Tests/StreamCoreTests/Utils/RepeatingTimer_Tests.swift
@@ -18,6 +18,21 @@ final class RepeatingTimer_Tests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    func test_scheduleRepeating_doesNotFireBeforeInterval() {
+        let interval: TimeInterval = 0.2
+        let timerDidFire = expectation(description: "Timer fires")
+        timerDidFire.isInverted = true
+
+        let subject = DefaultTimer.scheduleRepeating(
+            timeInterval: interval,
+            queue: .global(),
+            onFire: { timerDidFire.fulfill() }
+        )
+        subject.resume()
+
+        wait(for: [timerDidFire], timeout: interval / 2)
+    }
+
     func test_deinit_whenResumed_doesNotCrash() {
         var repeatingTimer: RepeatingTimerControl? = DefaultTimer.scheduleRepeating(
             timeInterval: 0.4,


### PR DESCRIPTION
### 🔗 Issue Links

N/A

### 🎯 Goal

Honor the requested interval before a repeating timer's first fire.

### 📝 Summary

- Schedule the first deadline using the `TimeInterval` value in seconds.
- Add a regression test that rejects an early first fire.

### 🛠 Implementation

Uses the native `DispatchTime + TimeInterval` operation already used by the
one-shot timer. This avoids interpreting a seconds value as milliseconds and
preserves fractional intervals.

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

Automated timing coverage verifies the behavior. No manual QA is required.

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
