### PR TITLE
[Fix] Correct repeating timer initial deadline

### DIFF
--- a/Sources/StreamCore/Utils/Timers.swift
+++ b/Sources/StreamCore/Utils/Timers.swift
@@ -125,7 +125,11 @@ private class RepeatingTimer: RepeatingTimerControl, @unchecked Sendable {
 
     init(timeInterval: TimeInterval, queue: DispatchQueue, onFire: @escaping () -> Void) {
         timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now() + .milliseconds(Int(timeInterval)), repeating: timeInterval, leeway: .seconds(1))
+        timer.schedule(
+            deadline: .now() + timeInterval,
+            repeating: timeInterval,
+            leeway: .seconds(1)
+        )
         timer.setEventHandler(handler: onFire)
     }
 

--- a/Tests/StreamCoreTests/Utils/RepeatingTimer_Tests.swift
+++ b/Tests/StreamCoreTests/Utils/RepeatingTimer_Tests.swift
@@ -6,6 +6,37 @@
 import XCTest
 
 final class RepeatingTimer_Tests: XCTestCase, @unchecked Sendable {
+    func test_scheduleRepeating_waitsForConfiguredIntervalBetweenFires() {
+        let interval: TimeInterval = 0.2
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+        var fireTimes: [UInt64] = []
+        let fired = expectation(description: "Timer fired twice")
+        fired.expectedFulfillmentCount = 2
+        let repeatingTimer = DefaultTimer.scheduleRepeating(
+            timeInterval: interval,
+            queue: .main
+        ) {
+            fireTimes.append(DispatchTime.now().uptimeNanoseconds)
+            fired.fulfill()
+        }
+
+        repeatingTimer.resume()
+        wait(for: [fired], timeout: 2)
+        repeatingTimer.suspend()
+
+        guard fireTimes.count == 2 else {
+            return XCTFail("Expected exactly two timer fires.")
+        }
+        XCTAssertGreaterThanOrEqual(
+            TimeInterval(fireTimes[0] - startedAt) / 1_000_000_000,
+            interval / 2
+        )
+        XCTAssertGreaterThanOrEqual(
+            TimeInterval(fireTimes[1] - fireTimes[0]) / 1_000_000_000,
+            interval / 2
+        )
+    }
+
     func test_state_isThreadSafe() {
         DispatchQueue.concurrentPerform(iterations: 10000) { _ in
             let repeatingTimer: RepeatingTimerControl? = DefaultTimer.scheduleRepeating(


### PR DESCRIPTION
### 🎯 Goal

Ensure repeating timers wait for their configured interval before their first
fire.

The initial deadline currently converts `TimeInterval` to milliseconds:

    .now() + .milliseconds(Int(timeInterval))

The repeating interval uses `TimeInterval` directly, which represents seconds.
Consequently, an interval of `5` produces a first deadline after 5 milliseconds
but repeats every 5 seconds.

### 📝 Summary

- Use the configured `TimeInterval` for both the initial deadline and repeating
  interval.
- Preserve fractional intervals without truncating them to an integer.
- Add regression coverage for the first and subsequent timer fires.
- Restore StreamVideo's pre-migration WebSocket ping timing.

### 🛠 Implementation

Schedule the repeating timer using:

    timer.schedule(
        deadline: .now() + timeInterval,
        repeating: timeInterval,
        leeway: .seconds(1)
    )

This retains the existing implementation and leeway while ensuring the initial
deadline uses the same unit and value as subsequent repetitions.

#### StreamVideo impact

The StreamVideo StreamCore migration configures both WebSocket clients with a
5-second ping interval:

- The Coordinator WebSocket sends a WebSocket ping.
- The SFU WebSocket sends an SFU health-check request.

With the previous StreamCore implementation, the first deadline was only
5 milliseconds. The timer is suspended until the connection becomes connected,
but its deadline continues to elapse. Resuming it after connection therefore
usually caused the first ping to fire immediately.

Sending that ping also starts the 3-second pong timeout, allowing a newly
connected socket to be classified as unhealthy earlier than it was before the
migration.

After this change, the first ping occurs after approximately 5 seconds and
subsequent pings continue every 5 seconds. This matches StreamVideo's
pre-migration behavior.

This change is independent of `healthCheckBeforeConnected`. That option controls
when the connected state is published relative to health checking; it does not
control timer scheduling.

#### StreamChat impact

StreamChat is not directly affected by this PR because its WebSocket stack owns
and compiles a separate timer and ping-controller implementation. It does not
currently use StreamCore for this path.

However, StreamChat's local repeating timer uses the same milliseconds
conversion. Its configured 25-second ping interval therefore has an initial
deadline of 25 milliseconds followed by repetitions every 25 seconds.

This PR does not change StreamChat's behavior, but StreamChat is potentially
exposed to the same immediate-first-ping behavior. It will require an equivalent
local fix or adoption of the corrected StreamCore timer.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo