### PR TITLE
[CI] Add verbose input to smoke and cron checks

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -6,6 +6,12 @@ on:
     - cron: '0 4 * * 1-5'
 
   workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Run tests in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +20,7 @@ concurrency:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 permissions:
   contents: read
@@ -57,13 +64,13 @@ jobs:
         version: ${{ matrix.ios }}
         device: ${{ matrix.device }}
     - name: Run Core Tests
-      run: bundle exec fastlane test_core device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true
+      run: bundle exec fastlane test_core device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true ${{ env.VERBOSE }}
       timeout-minutes: 30
     - name: Run UI Tests
-      run: bundle exec fastlane test_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true
+      run: bundle exec fastlane test_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true ${{ env.VERBOSE }}
       timeout-minutes: 30
     - name: Run Attachments Tests
-      run: bundle exec fastlane test_attachments device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true
+      run: bundle exec fastlane test_attachments device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true ${{ env.VERBOSE }}
       timeout-minutes: 30
 
   automated-code-review:

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -13,6 +13,11 @@ on:
         type: boolean
         required: false
         default: false
+      verbose:
+        description: 'Run tests in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,6 +28,7 @@ env:
   IOS_SIMULATOR_DEVICE: "iPhone 17 Pro (26.2)"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 permissions:
   contents: read
@@ -41,7 +47,7 @@ jobs:
         INSTALL_YEETD: true
         INSTALL_SONAR: true
     - name: Run Core Tests (Debug)
-      run: bundle exec fastlane test_core device:"${{ env.IOS_SIMULATOR_DEVICE }}"
+      run: bundle exec fastlane test_core device:"${{ env.IOS_SIMULATOR_DEVICE }}" ${{ env.VERBOSE }}
       timeout-minutes: 40
     - name: Run Sonar analysis
       run: bundle exec fastlane sonar_upload
@@ -86,7 +92,7 @@ jobs:
       env:
         INSTALL_YEETD: true
     - name: Run UI Tests (Debug)
-      run: bundle exec fastlane test_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}"
+      run: bundle exec fastlane test_ui device:"${{ env.IOS_SIMULATOR_DEVICE }}" ${{ env.VERBOSE }}
       timeout-minutes: 40
     - uses: 8398a7/action-slack@v3
       with:
@@ -109,7 +115,7 @@ jobs:
       env:
         INSTALL_YEETD: true
     - name: Run Attachments Tests (Debug)
-      run: bundle exec fastlane test_attachments device:"${{ env.IOS_SIMULATOR_DEVICE }}"
+      run: bundle exec fastlane test_attachments device:"${{ env.IOS_SIMULATOR_DEVICE }}" ${{ env.VERBOSE }}
       timeout-minutes: 40
     - uses: 8398a7/action-slack@v3
       with:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,7 @@ source_packages_path = 'spm_cache'
 swift_environment_path = File.absolute_path("../Sources/#{sdk_names.first}/Utils/SystemEnvironment+Version.swift")
 is_localhost = !is_ci
 @force_check = false
+xcodebuild_formatter = FastlaneCore::Globals.verbose? ? '' : nil
 
 before_all do |lane|
   if is_ci
@@ -114,7 +115,8 @@ private_lane :run_library_tests do |options|
     devices: options[:device],
     number_of_retries: 3,
     skip_build: options[:skip_build],
-    build_for_testing: options[:build_for_testing]
+    build_for_testing: options[:build_for_testing],
+    xcodebuild_formatter: xcodebuild_formatter
   }
 
   scan(scan_options)


### PR DESCRIPTION
### 🎯 Goal

When a CI test job fails for a non-obvious reason, get the unfiltered `xcodebuild` output without having to edit the workflow, push, and wait.

### 🛠 Implementation

- New `workflow_dispatch` input `verbose` (boolean, **default `false`**) on `smoke-checks.yml` and `cron-checks.yml`.
- One workflow-level env instead of repeating the expression per step:
  ```yaml
  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
  ```
  appended as `${{ env.VERBOSE }}` to the test steps only (build-only steps are left alone).
- `Fastfile` bridges the flag into `scan`, so `--verbose` also stops the output being formatted:
  ```ruby
  xcodebuild_formatter = FastlaneCore::Globals.verbose? ? '' : nil
  ```
  passed to the `scan` calls of the test lanes. No lane option needed — fastlane sets `Globals.verbose` from `ARGV` before the `Fastfile` is loaded.

On `pull_request` / `schedule` runs the input is absent, the expression yields `''`, and both the commands and the `scan` config are identical to today (`nil` keeps fastlane's default formatter).

### 🧐 Why `xcodebuild_formatter: ''` and not `output_style: 'raw'`

Both drop the formatter, but who writes `test_output/report.junit` depends on the *resolved* formatter: xcpretty's pipe when it resolves to `xcpretty`, otherwise trainer parsing the xcresult. `output_style: 'raw'` removes the pipe while leaving the resolved formatter at `xcpretty`, so no junit is written and the `retreive_failed_tests` retry path dies with "There is no junit report to parse", masking the real failure. `xcodebuild_formatter: ''` moves junit generation to trainer, so retries keep working. This matters because the default is dynamic — `xcbeautify` if installed, else `xcpretty`.

### 🧪 Verification

- Probed the repo's own fastlane (2.228.0) with a real `Scan.config`: unset → resolved `"xcpretty"`, pipe `| tee <log> | xcpretty --report junit …`; `''` → resolved `""`, pipe `| tee <log>` only, junit via trainer.
- `bundle exec fastlane rubocop` clean; workflows parse as YAML.
- No new secret exposure: no secret is passed as a CLI arg or into xcodebuild by these lanes, `--verbose` does not dump `ENV`, fastlane masks `sensitive:` config items, and raw xcodebuild output echoes build settings rather than the runner environment.

Same change is being applied across the iOS SDK repos.
