### PR TITLE
Bump stream_actions plugin to 0.4.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
       bundler
       fastlane
       pry
-    fastlane-plugin-stream_actions (0.3.102)
+    fastlane-plugin-stream_actions (0.4.7)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-sirp (1.0.0)
@@ -349,7 +349,7 @@ DEPENDENCIES
   danger-commit_lint
   fastlane
   fastlane-plugin-lizard
-  fastlane-plugin-stream_actions (= 0.3.102)
+  fastlane-plugin-stream_actions (= 0.4.7)
   fastlane-plugin-versioning
   json
   lefthook

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-versioning'
-gem 'fastlane-plugin-stream_actions', '0.3.102'
+gem 'fastlane-plugin-stream_actions', '0.4.7'


### PR DESCRIPTION
Resolve: https://linear.app/stream/issue/IOS-1942

### 🎯 Goal

Pick up `fastlane-plugin-stream_actions` [0.4.7](https://github.com/GetStream/fastlane-plugin-stream_actions), which strips invisible Unicode leftovers (`U+FE0E`/`U+FE0F`/`U+200D`) from the TestFlight changelog before handing it to pilot. Pilot removes emoji but leaves these companions behind, and App Store Connect rejects them — this silently failed every stream-chat-swift 5.8.0 and stream-chat-swiftui 5.7.0/5.8.0 demo deploy with `Text for whatsNew contains invalid characters:'[️]'`.

### 🛠 Implementation

- `fastlane-plugin-stream_actions` 0.3.102 → 0.4.7 (`Pluginfile` + lockfile). This repo's changelog has no variation selectors, so this is preventive.

Same bump applied across the iOS SDK repos.

Since this is a bigger jump: verified the Fastfile loads under 0.4.7 and no plugin actions used here were removed between 0.3.102 and 0.4.7 (only `core_version` and `next_pr_number` were added).

