### PR TITLE
[CI] Lint Package.swift before release and verify it after release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -28,6 +28,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_GITHUB_TOKEN }}
         run: bundle exec fastlane publish_release --verbose
 
+      - name: Integration Test
+        run: | # reports to @support on failure
+          version=$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)
+          gh workflow run test.yml --repo GetStream/apple-internal-testing-pipeline --field sdk=stream-core-swift --field version="$version"
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_GITHUB_TOKEN }}
+
   merge-main-to-develop:
     name: Merge main to develop
     runs-on: ubuntu-latest

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Integration Test
         run: | # reports to @support on failure
-          version=$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)
-          gh workflow run test.yml --repo GetStream/apple-internal-testing-pipeline --field sdk=stream-core-swift --field version="$version"
+          test -n "$RELEASE_VERSION"
+          gh workflow run test.yml --repo GetStream/apple-internal-testing-pipeline --field sdk=stream-core-swift --field version="$RELEASE_VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_GITHUB_TOKEN }}
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
       bundler
       fastlane
       pry
-    fastlane-plugin-stream_actions (0.4.7)
+    fastlane-plugin-stream_actions (0.4.8)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-sirp (1.0.0)
@@ -349,7 +349,7 @@ DEPENDENCIES
   danger-commit_lint
   fastlane
   fastlane-plugin-lizard
-  fastlane-plugin-stream_actions (= 0.4.7)
+  fastlane-plugin-stream_actions (= 0.4.8)
   fastlane-plugin-versioning
   json
   lefthook

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,6 +68,7 @@ lane :publish_release do |options|
   release_version = get_sdk_version_from_environment
   UI.user_error!("Release #{release_version} has already been published.") if git_tag_exists(tag: release_version, remote: true)
   UI.user_error!('Release version cannot be empty') if release_version.to_s.empty?
+  File.write(ENV['GITHUB_ENV'], "RELEASE_VERSION=#{release_version}\n", mode: 'a') if ENV['GITHUB_ENV']
 
   ensure_git_branch(branch: 'main')
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,7 +35,9 @@ lane :release do |options|
     File.open(swift_environment_path, 'w') { |f| f.puts(new_content) }
   end
 
+  lint_swift_package
   check_unsafe_flags
+
   release_ios_sdk(
     version: options[:version],
     bump_type: options[:type],

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-versioning'
-gem 'fastlane-plugin-stream_actions', '0.4.7'
+gem 'fastlane-plugin-stream_actions', '0.4.8'


### PR DESCRIPTION
Resolves: https://linear.app/stream/issue/IOS-1934
Resolves: https://linear.app/stream/issue/IOS-1741

### 🎯 Goal

Verify package health at both ends of a release: block bad `Package.swift` pins **before** publishing, and integration-test the actually released versions **after** publishing (until now the post-release pipeline run tested develop tips).

### 🛠 Implementation

- Bump `fastlane-plugin-stream_actions` to 0.4.8, which brings the new `lint_swift_package` action and a default changelog entry when a release section is empty (IOS-1741).
- The `release` lane now runs `lint_swift_package` — it fails on branch/revision pins, version ranges, local-path deps, non-https urls, and duplicates in `Package.swift`; only `from:`/`exact:` pins pass.
- `release-publish.yml` passes `sdk` + the just-published version (from `gh release view`) to [apple-internal-testing-pipeline](https://github.com/GetStream/apple-internal-testing-pipeline), which pins this SDK to that exact version and all other Stream SDKs to their latest released versions.

Note: StreamCore isn't a direct dependency of the pipeline's test projects, so a core release run retests the latest released SDK combo; the new core version enters the graph once the SDKs re-release with a bumped core pin.
