### PR TITLE
Bump fastlane-plugin-stream_actions to 0.4.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
       bundler
       fastlane
       pry
-    fastlane-plugin-stream_actions (0.4.8)
+    fastlane-plugin-stream_actions (0.4.9)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-sirp (1.0.0)
@@ -349,7 +349,7 @@ DEPENDENCIES
   danger-commit_lint
   fastlane
   fastlane-plugin-lizard
-  fastlane-plugin-stream_actions (= 0.4.8)
+  fastlane-plugin-stream_actions (= 0.4.9)
   fastlane-plugin-versioning
   json
   lefthook

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-versioning'
-gem 'fastlane-plugin-stream_actions', '0.4.8'
+gem 'fastlane-plugin-stream_actions', '0.4.9'


### PR DESCRIPTION
Fixes https://linear.app/stream/issue/IOS-1942

### 🎯 Goal

Fix TestFlight deploys failing at the changelog step when it contains text-presentation symbols like `⚠` (App Store Connect rejects them in `whatsNew`, and pilot's emoji stripper misses them).

### 📝 Summary

- Bump `fastlane-plugin-stream_actions` to 0.4.9, which strips all pictographs and their invisible companions from the TestFlight changelog before upload.